### PR TITLE
Feature/fix 64 change regulatory requirement for e cpf

### DIFF
--- a/open-banking-brasil-certificate-standards-1_ID1.html
+++ b/open-banking-brasil-certificate-standards-1_ID1.html
@@ -1,21 +1,31 @@
 <!DOCTYPE html>
 <html lang="en" class="Internet-Draft">
-<head>
-<meta charset="utf-8">
-<meta content="Common,Latin" name="scripts">
-<meta content="initial-scale=1.0" name="viewport">
-<title>Open Banking Brasil Certificate Standards 1.0 Implementers Draft 1</title>
-<meta content="Marcos Rodrigues" name="author">
-<meta content="Jose Michael Dias" name="author">
-<meta content="OBBIS GT Security" name="author">
-<meta content="xml2rfc 2.40.1" name="generator">
-<meta content="FAPI" name="keyword">
-<meta content="CERT" name="keyword">
-<meta content="Open Banking Brasil GT Security" name="keyword">
-<meta content="open-banking-brasil-certificate-standards-1_ID1" name="ietf.draft">
-<link href="./open-banking-brasil-certificate-standards-1_ID1.xml" rel="alternate" type="application/rfc+xml">
-<link href="#copyright" rel="license">
-<style type="text/css">/*
+  <head>
+    <meta charset="utf-8" />
+    <meta content="Common,Latin" name="scripts" />
+    <meta content="initial-scale=1.0" name="viewport" />
+    <title>
+      Open Banking Brasil Certificate Standards 1.0 Implementers Draft 1
+    </title>
+    <meta content="Marcos Rodrigues" name="author" />
+    <meta content="Jose Michael Dias" name="author" />
+    <meta content="OBBIS GT Security" name="author" />
+    <meta content="xml2rfc 2.40.1" name="generator" />
+    <meta content="FAPI" name="keyword" />
+    <meta content="CERT" name="keyword" />
+    <meta content="Open Banking Brasil GT Security" name="keyword" />
+    <meta
+      content="open-banking-brasil-certificate-standards-1_ID1"
+      name="ietf.draft"
+    />
+    <link
+      href="./open-banking-brasil-certificate-standards-1_ID1.xml"
+      rel="alternate"
+      type="application/rfc+xml"
+    />
+    <link href="#copyright" rel="license" />
+    <style type="text/css">
+      /*
 
   NOTE: Changes at the bottom of this file overrides some earlier settings.
 
@@ -28,628 +38,662 @@
 
 */
 
-/* fonts */
-@import url('https://fonts.googleapis.com/css?family=Noto+Sans'); /* Sans-serif */
-@import url('https://fonts.googleapis.com/css?family=Noto+Serif'); /* Serif (print) */
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono'); /* Monospace */
+      /* fonts */
+      @import url("https://fonts.googleapis.com/css?family=Noto+Sans"); /* Sans-serif */
+      @import url("https://fonts.googleapis.com/css?family=Noto+Serif"); /* Serif (print) */
+      @import url("https://fonts.googleapis.com/css?family=Roboto+Mono"); /* Monospace */
 
-@viewport {
-  zoom: 1.0;
-  width: extend-to-zoom;
-}
-@-ms-viewport {
-  width: extend-to-zoom;
-  zoom: 1.0;
-}
-/* general and mobile first */
-html {
-}
-body {
-  max-width: 90%;
-  margin: 1.5em auto;
-  color: #222;
-  background-color: #fff;
-  font-size: 14px;
-  font-family: 'Noto Sans', Arial, Helvetica, sans-serif;
-  line-height: 1.6;
-  scroll-behavior: smooth;
-}
-.ears {
-  display: none;
-}
+      @viewport {
+        zoom: 1;
+        width: extend-to-zoom;
+      }
+      @-ms-viewport {
+        width: extend-to-zoom;
+        zoom: 1;
+      }
+      /* general and mobile first */
+      html {
+      }
+      body {
+        max-width: 90%;
+        margin: 1.5em auto;
+        color: #222;
+        background-color: #fff;
+        font-size: 14px;
+        font-family: "Noto Sans", Arial, Helvetica, sans-serif;
+        line-height: 1.6;
+        scroll-behavior: smooth;
+      }
+      .ears {
+        display: none;
+      }
 
-/* headings */
-#title, h1, h2, h3, h4, h5, h6 {
-  margin: 1em 0 0.5em;
-  font-weight: bold;
-  line-height: 1.3;
-}
-#title {
-  clear: both;
-  border-bottom: 1px solid #ddd;
-  margin: 0 0 0.5em 0;
-  padding: 1em 0 0.5em;
-}
-.author {
-  padding-bottom: 4px;
-}
-h1 {
-  font-size: 26px;
-  margin: 1em 0;
-}
-h2 {
-  font-size: 22px;
-  margin-top: -20px;  /* provide offset for in-page anchors */
-  padding-top: 33px;
-}
-h3 {
-  font-size: 18px;
-  margin-top: -36px;  /* provide offset for in-page anchors */
-  padding-top: 42px;
-}
-h4 {
-  font-size: 16px;
-  margin-top: -36px;  /* provide offset for in-page anchors */
-  padding-top: 42px;
-}
-h5, h6 {
-  font-size: 14px;
-}
-#n-copyright-notice {
-  border-bottom: 1px solid #ddd;
-  padding-bottom: 1em;
-  margin-bottom: 1em;
-}
-/* general structure */
-p {
-  padding: 0;
-  margin: 0 0 1em 0;
-  text-align: left;
-}
-div, span {
-  position: relative;
-}
-div {
-  margin: 0;
-}
-.alignRight.art-text {
-  background-color: #f9f9f9;
-  border: 1px solid #eee;
-  border-radius: 3px;
-  padding: 1em 1em 0;
-  margin-bottom: 1.5em;
-}
-.alignRight.art-text pre {
-  padding: 0;
-}
-.alignRight {
-  margin: 1em 0;
-}
-.alignRight > *:first-child {
-  border: none;
-  margin: 0;
-  float: right;
-  clear: both;
-}
-.alignRight > *:nth-child(2) {
-  clear: both;
-  display: block;
-  border: none;
-}
-svg {
-  display: block;
-}
-.alignCenter.art-text {
-  background-color: #f9f9f9;
-  border: 1px solid #eee;
-  border-radius: 3px;
-  padding: 1em 1em 0;
-  margin-bottom: 1.5em;
-}
-.alignCenter.art-text pre {
-  padding: 0;
-}
-.alignCenter {
-  margin: 1em 0;
-}
-.alignCenter > *:first-child {
-  border: none;
-  /* this isn't optimal, but it's an existence proof.  PrinceXML doesn't
+      /* headings */
+      #title,
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        margin: 1em 0 0.5em;
+        font-weight: bold;
+        line-height: 1.3;
+      }
+      #title {
+        clear: both;
+        border-bottom: 1px solid #ddd;
+        margin: 0 0 0.5em 0;
+        padding: 1em 0 0.5em;
+      }
+      .author {
+        padding-bottom: 4px;
+      }
+      h1 {
+        font-size: 26px;
+        margin: 1em 0;
+      }
+      h2 {
+        font-size: 22px;
+        margin-top: -20px; /* provide offset for in-page anchors */
+        padding-top: 33px;
+      }
+      h3 {
+        font-size: 18px;
+        margin-top: -36px; /* provide offset for in-page anchors */
+        padding-top: 42px;
+      }
+      h4 {
+        font-size: 16px;
+        margin-top: -36px; /* provide offset for in-page anchors */
+        padding-top: 42px;
+      }
+      h5,
+      h6 {
+        font-size: 14px;
+      }
+      #n-copyright-notice {
+        border-bottom: 1px solid #ddd;
+        padding-bottom: 1em;
+        margin-bottom: 1em;
+      }
+      /* general structure */
+      p {
+        padding: 0;
+        margin: 0 0 1em 0;
+        text-align: left;
+      }
+      div,
+      span {
+        position: relative;
+      }
+      div {
+        margin: 0;
+      }
+      .alignRight.art-text {
+        background-color: #f9f9f9;
+        border: 1px solid #eee;
+        border-radius: 3px;
+        padding: 1em 1em 0;
+        margin-bottom: 1.5em;
+      }
+      .alignRight.art-text pre {
+        padding: 0;
+      }
+      .alignRight {
+        margin: 1em 0;
+      }
+      .alignRight > *:first-child {
+        border: none;
+        margin: 0;
+        float: right;
+        clear: both;
+      }
+      .alignRight > *:nth-child(2) {
+        clear: both;
+        display: block;
+        border: none;
+      }
+      svg {
+        display: block;
+      }
+      .alignCenter.art-text {
+        background-color: #f9f9f9;
+        border: 1px solid #eee;
+        border-radius: 3px;
+        padding: 1em 1em 0;
+        margin-bottom: 1.5em;
+      }
+      .alignCenter.art-text pre {
+        padding: 0;
+      }
+      .alignCenter {
+        margin: 1em 0;
+      }
+      .alignCenter > *:first-child {
+        border: none;
+        /* this isn't optimal, but it's an existence proof.  PrinceXML doesn't
      support flexbox yet.
   */
-  display: table;
-  margin: 0 auto;
-}
+        display: table;
+        margin: 0 auto;
+      }
 
-/* lists */
-ol, ul {
-  padding: 0;
-  margin: 0 0 1em 2em;
-}
-ol ol, ul ul, ol ul, ul ol {
-  margin-left: 1em;
-}
-li {
-  margin: 0 0 0.25em 0;
-}
-.ulCompact li {
-  margin: 0;
-}
-ul.empty, .ulEmpty {
-  list-style-type: none;
-}
-ul.empty li, .ulEmpty li {
-  margin-top: 0.5em;
-}
-ul.compact, .ulCompact,
-ol.compact, .olCompact {
-  line-height: 100%;
-  margin: 0 0 0 2em;
-}
+      /* lists */
+      ol,
+      ul {
+        padding: 0;
+        margin: 0 0 1em 2em;
+      }
+      ol ol,
+      ul ul,
+      ol ul,
+      ul ol {
+        margin-left: 1em;
+      }
+      li {
+        margin: 0 0 0.25em 0;
+      }
+      .ulCompact li {
+        margin: 0;
+      }
+      ul.empty,
+      .ulEmpty {
+        list-style-type: none;
+      }
+      ul.empty li,
+      .ulEmpty li {
+        margin-top: 0.5em;
+      }
+      ul.compact,
+      .ulCompact,
+      ol.compact,
+      .olCompact {
+        line-height: 100%;
+        margin: 0 0 0 2em;
+      }
 
-/* definition lists */
-dl {
-}
-dl > dt {
-  float: left;
-  margin-right: 1em;
-}
-/* 
+      /* definition lists */
+      dl {
+      }
+      dl > dt {
+        float: left;
+        margin-right: 1em;
+      }
+      /* 
 dl.nohang > dt {
   float: none;
 }
 */
-dl > dd {
-  margin-bottom: .8em;
-  min-height: 1.3em;
-}
-dl.compact > dd, .dlCompact > dd {
-  margin-bottom: 0em;
-}
-dl > dd > dl {
-  margin-top: 0.5em;
-  margin-bottom: 0em;
-}
+      dl > dd {
+        margin-bottom: 0.8em;
+        min-height: 1.3em;
+      }
+      dl.compact > dd,
+      .dlCompact > dd {
+        margin-bottom: 0em;
+      }
+      dl > dd > dl {
+        margin-top: 0.5em;
+        margin-bottom: 0em;
+      }
 
-/* links */
-a {
-  text-decoration: none;
-}
-a[href] {
-  color: #22e; /* Arlen: WCAG 2019 */
-}
-a[href]:hover {
-  background-color: #f2f2f2;
-}
-figcaption a[href],
-a[href].selfRef {
-  color: #222;
-}
-/* XXX probably not this:
+      /* links */
+      a {
+        text-decoration: none;
+      }
+      a[href] {
+        color: #22e; /* Arlen: WCAG 2019 */
+      }
+      a[href]:hover {
+        background-color: #f2f2f2;
+      }
+      figcaption a[href],
+      a[href].selfRef {
+        color: #222;
+      }
+      /* XXX probably not this:
 a.selfRef:hover {
   background-color: transparent;
   cursor: default;
 } */
 
-/* Figures */
-tt, code, pre, code {
-  background-color: #f9f9f9;
-  font-family: 'Roboto Mono', monospace;
-}
-pre {
-  border: 1px solid #eee;
-  margin: 0;
-  padding: 1em;
-}
-img {
-  max-width: 100%;
-}
-figure {
-  margin: 0;
-}
-figure blockquote {
-  margin: 0.8em 0.4em 0.4em;
-}
-figcaption {
-  font-style: italic;
-  margin: 0 0 1em 0;
-}
-@media screen {
-  pre {
-    overflow-x: auto;
-    max-width: 100%;
-    max-width: calc(100% - 22px);
-  }
-}
+      /* Figures */
+      tt,
+      code,
+      pre,
+      code {
+        background-color: #f9f9f9;
+        font-family: "Roboto Mono", monospace;
+      }
+      pre {
+        border: 1px solid #eee;
+        margin: 0;
+        padding: 1em;
+      }
+      img {
+        max-width: 100%;
+      }
+      figure {
+        margin: 0;
+      }
+      figure blockquote {
+        margin: 0.8em 0.4em 0.4em;
+      }
+      figcaption {
+        font-style: italic;
+        margin: 0 0 1em 0;
+      }
+      @media screen {
+        pre {
+          overflow-x: auto;
+          max-width: 100%;
+          max-width: calc(100% - 22px);
+        }
+      }
 
-/* aside, blockquote */
-aside, blockquote {
-  margin-left: 0;
-  padding: 1.2em 2em;
-}
-blockquote {
-  background-color: #f9f9f9;
-  color: #111; /* Arlen: WCAG 2019 */
-  border: 1px solid #ddd;
-  border-radius: 3px;
-  margin: 1em 0;
-}
-cite {
-  display: block;
-  text-align: right;
-  font-style: italic;
-}
+      /* aside, blockquote */
+      aside,
+      blockquote {
+        margin-left: 0;
+        padding: 1.2em 2em;
+      }
+      blockquote {
+        background-color: #f9f9f9;
+        color: #111; /* Arlen: WCAG 2019 */
+        border: 1px solid #ddd;
+        border-radius: 3px;
+        margin: 1em 0;
+      }
+      cite {
+        display: block;
+        text-align: right;
+        font-style: italic;
+      }
 
-/* tables */
-table {
-  width: 100%;
-  margin: 0 0 1em;
-  border-collapse: collapse;
-  border: 1px solid #eee;
-}
-th, td {
-  text-align: left;
-  vertical-align: top;
-  padding: 0.5em 0.75em;
-}
-th {
-  text-align: left;
-  background-color: #e9e9e9;
-}
-tr:nth-child(2n+1) > td {
-  background-color: #f5f5f5;
-}
-table caption {
-  font-style: italic;
-  margin: 0;
-  padding: 0;
-  text-align: left;
-}
-table p {
-  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+      /* tables */
+      table {
+        width: 100%;
+        margin: 0 0 1em;
+        border-collapse: collapse;
+        border: 1px solid #eee;
+      }
+      th,
+      td {
+        text-align: left;
+        vertical-align: top;
+        padding: 0.5em 0.75em;
+      }
+      th {
+        text-align: left;
+        background-color: #e9e9e9;
+      }
+      tr:nth-child(2n + 1) > td {
+        background-color: #f5f5f5;
+      }
+      table caption {
+        font-style: italic;
+        margin: 0;
+        padding: 0;
+        text-align: left;
+      }
+      table p {
+        /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
      be allowed within tables more generally, it would be far better to select on a class. */
-  margin: 0;
-}
+        margin: 0;
+      }
 
-/* pilcrow */
-a.pilcrow {
-  color: #666; /* Arlen: AHDJ 2019 */
-  text-decoration: none;
-  visibility: hidden;
-  user-select: none;
-  -ms-user-select: none;
-  -o-user-select:none;
-  -moz-user-select: none;
-  -khtml-user-select: none;
-  -webkit-user-select: none;
-  -webkit-touch-callout: none;
-}
-@media screen {
-  aside:hover > a.pilcrow,
-  p:hover > a.pilcrow,
-  blockquote:hover > a.pilcrow,
-  div:hover > a.pilcrow,
-  li:hover > a.pilcrow,
-  pre:hover > a.pilcrow {
-    visibility: visible;
-  }
-  a.pilcrow:hover {
-    background-color: transparent;
-  }
-}
+      /* pilcrow */
+      a.pilcrow {
+        color: #666; /* Arlen: AHDJ 2019 */
+        text-decoration: none;
+        visibility: hidden;
+        user-select: none;
+        -ms-user-select: none;
+        -o-user-select: none;
+        -moz-user-select: none;
+        -khtml-user-select: none;
+        -webkit-user-select: none;
+        -webkit-touch-callout: none;
+      }
+      @media screen {
+        aside:hover > a.pilcrow,
+        p:hover > a.pilcrow,
+        blockquote:hover > a.pilcrow,
+        div:hover > a.pilcrow,
+        li:hover > a.pilcrow,
+        pre:hover > a.pilcrow {
+          visibility: visible;
+        }
+        a.pilcrow:hover {
+          background-color: transparent;
+        }
+      }
 
-/* misc */
-hr {
-  border: 0;
-  border-top: 1px solid #eee;
-}
-.bcp14 {
-  font-variant: small-caps;
-}
+      /* misc */
+      hr {
+        border: 0;
+        border-top: 1px solid #eee;
+      }
+      .bcp14 {
+        font-variant: small-caps;
+      }
 
-.role {
-  font-variant: all-small-caps;
-}
+      .role {
+        font-variant: all-small-caps;
+      }
 
-/* info block */
-#identifiers {
-  margin: 0;
-  font-size: 0.9em;
-}
-#identifiers dt {
-  width: 3em;
-  clear: left;
-}
-#identifiers dd {
-  float: left;
-  margin-bottom: 0;
-}
-#identifiers .authors .author {
-  display: inline-block;
-  margin-right: 1.5em;
-}
-#identifiers .authors .org {
-  font-style: italic;
-}
+      /* info block */
+      #identifiers {
+        margin: 0;
+        font-size: 0.9em;
+      }
+      #identifiers dt {
+        width: 3em;
+        clear: left;
+      }
+      #identifiers dd {
+        float: left;
+        margin-bottom: 0;
+      }
+      #identifiers .authors .author {
+        display: inline-block;
+        margin-right: 1.5em;
+      }
+      #identifiers .authors .org {
+        font-style: italic;
+      }
 
-/* The prepared/rendered info at the very bottom of the page */
-.docInfo {
-  color: #666; /* Arlen: WCAG 2019 */
-  font-size: 0.9em;
-  font-style: italic;
-  margin-top: 2em;
-}
-.docInfo .prepared {
-  float: left;
-}
-.docInfo .prepared {
-  float: right;
-}
+      /* The prepared/rendered info at the very bottom of the page */
+      .docInfo {
+        color: #666; /* Arlen: WCAG 2019 */
+        font-size: 0.9em;
+        font-style: italic;
+        margin-top: 2em;
+      }
+      .docInfo .prepared {
+        float: left;
+      }
+      .docInfo .prepared {
+        float: right;
+      }
 
-/* table of contents */
-#toc  {
-  padding: 0.75em 0 2em 0;
-  margin-bottom: 1em;
-}
-nav.toc ul {
-  margin: 0 0.5em 0 0;
-  padding: 0;
-  list-style: none;
-}
-nav.toc li {
-  line-height: 1.3em;
-  margin: 0.75em 0;
-  padding-left: 1.2em;
-  text-indent: -1.2em;
-}
-/* references */
-.references dt {
-  text-align: right;
-  font-weight: bold;
-  min-width: 7em;
-}
-.references dd {
-  margin-left: 8em;
-  overflow: auto;
-}
+      /* table of contents */
+      #toc {
+        padding: 0.75em 0 2em 0;
+        margin-bottom: 1em;
+      }
+      nav.toc ul {
+        margin: 0 0.5em 0 0;
+        padding: 0;
+        list-style: none;
+      }
+      nav.toc li {
+        line-height: 1.3em;
+        margin: 0.75em 0;
+        padding-left: 1.2em;
+        text-indent: -1.2em;
+      }
+      /* references */
+      .references dt {
+        text-align: right;
+        font-weight: bold;
+        min-width: 7em;
+      }
+      .references dd {
+        margin-left: 8em;
+        overflow: auto;
+      }
 
-.refInstance {
-  margin-bottom: 1.25em;
-}
+      .refInstance {
+        margin-bottom: 1.25em;
+      }
 
-.references .ascii {
-  margin-bottom: 0.25em;
-}
+      .references .ascii {
+        margin-bottom: 0.25em;
+      }
 
-/* index */
-.index ul {
-  margin: 0 0 0 1em;
-  padding: 0;
-  list-style: none;
-}
-.index ul ul {
-  margin: 0;
-}
-.index li {
-  margin: 0;
-  text-indent: -2em;
-  padding-left: 2em;
-  padding-bottom: 5px;
-}
-.indexIndex {
-  margin: 0.5em 0 1em;
-}
-.index a {
-  font-weight: 700;
-}
-/* make the index two-column on all but the smallest screens */
-@media (min-width: 600px) {
-  .index ul {
-    -moz-column-count: 2;
-    -moz-column-gap: 20px;
-  }
-  .index ul ul {
-    -moz-column-count: 1;
-    -moz-column-gap: 0;
-  }
-}
+      /* index */
+      .index ul {
+        margin: 0 0 0 1em;
+        padding: 0;
+        list-style: none;
+      }
+      .index ul ul {
+        margin: 0;
+      }
+      .index li {
+        margin: 0;
+        text-indent: -2em;
+        padding-left: 2em;
+        padding-bottom: 5px;
+      }
+      .indexIndex {
+        margin: 0.5em 0 1em;
+      }
+      .index a {
+        font-weight: 700;
+      }
+      /* make the index two-column on all but the smallest screens */
+      @media (min-width: 600px) {
+        .index ul {
+          -moz-column-count: 2;
+          -moz-column-gap: 20px;
+        }
+        .index ul ul {
+          -moz-column-count: 1;
+          -moz-column-gap: 0;
+        }
+      }
 
-/* authors */
-address.vcard {
-  font-style: normal;
-  margin: 1em 0;
-}
+      /* authors */
+      address.vcard {
+        font-style: normal;
+        margin: 1em 0;
+      }
 
-address.vcard .nameRole {
-  font-weight: 700;
-  margin-left: 0;
-}
-address.vcard .label {
-  font-family: "Noto Sans",Arial,Helvetica,sans-serif;
-  margin: 0.5em 0;
-}
-address.vcard .type {
-  display: none;
-}
-.alternative-contact {
-  margin: 1.5em 0 1em;
-}
-hr.addr {
-  border-top: 1px dashed;
-  margin: 0;
-  color: #ddd;
-  max-width: calc(100% - 16px);
-}
+      address.vcard .nameRole {
+        font-weight: 700;
+        margin-left: 0;
+      }
+      address.vcard .label {
+        font-family: "Noto Sans", Arial, Helvetica, sans-serif;
+        margin: 0.5em 0;
+      }
+      address.vcard .type {
+        display: none;
+      }
+      .alternative-contact {
+        margin: 1.5em 0 1em;
+      }
+      hr.addr {
+        border-top: 1px dashed;
+        margin: 0;
+        color: #ddd;
+        max-width: calc(100% - 16px);
+      }
 
-/* temporary notes */
-.rfcEditorRemove::before {
-  position: absolute;
-  top: 0.2em;
-  right: 0.2em;
-  padding: 0.2em;
-  content: "The RFC Editor will remove this note";
-  color: #9e2a00; /* Arlen: WCAG 2019 */
-  background-color: #ffd; /* Arlen: WCAG 2019 */
-}
-.rfcEditorRemove {
-  position: relative;
-  padding-top: 1.8em;
-  background-color: #ffd; /* Arlen: WCAG 2019 */
-  border-radius: 3px;
-}
-.cref {
-  background-color: #ffd; /* Arlen: WCAG 2019 */
-  padding: 2px 4px;
-}
-.crefSource {
-  font-style: italic;
-}
-/* alternative layout for smaller screens */
-@media screen and (max-width: 1023px) {
-  body {
-    padding-top: 2em;
-  }
-  #title {
-    padding: 1em 0;
-  }
-  h1 {
-    font-size: 24px;
-  }
-  h2 {
-    font-size: 20px;
-    margin-top: -18px;  /* provide offset for in-page anchors */
-    padding-top: 38px;
-  }
-  #identifiers dd {
-    max-width: 60%;
-  }
-  #toc {
-    position: fixed;
-    z-index: 2;
-    top: 0;
-    right: 0;
-    padding: 0;
-    margin: 0;
-    background-color: inherit;
-    border-bottom: 1px solid #ccc;
-  }
-  #toc h2 {
-    margin: -1px 0 0 0;
-    padding: 4px 0 4px 6px;
-    padding-right: 1em;
-    min-width: 190px;
-    font-size: 1.1em;
-    text-align: right;
-    background-color: #444;
-    color: white;
-    cursor: pointer;
-  }
-  #toc h2::before { /* css hamburger */
-    float: right;
-    position: relative;
-    width: 1em;
-    height: 1px;
-    left: -164px;
-    margin: 6px 0 0 0;
-    background: white none repeat scroll 0 0;
-    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
-    content: "";
-  }
-  #toc nav {
-    display: none;
-    padding: 0.5em 1em 1em;
-    overflow: auto;
-    height: calc(100vh - 48px);
-    border-left: 1px solid #ddd;
-  }
-}
+      /* temporary notes */
+      .rfcEditorRemove::before {
+        position: absolute;
+        top: 0.2em;
+        right: 0.2em;
+        padding: 0.2em;
+        content: "The RFC Editor will remove this note";
+        color: #9e2a00; /* Arlen: WCAG 2019 */
+        background-color: #ffd; /* Arlen: WCAG 2019 */
+      }
+      .rfcEditorRemove {
+        position: relative;
+        padding-top: 1.8em;
+        background-color: #ffd; /* Arlen: WCAG 2019 */
+        border-radius: 3px;
+      }
+      .cref {
+        background-color: #ffd; /* Arlen: WCAG 2019 */
+        padding: 2px 4px;
+      }
+      .crefSource {
+        font-style: italic;
+      }
+      /* alternative layout for smaller screens */
+      @media screen and (max-width: 1023px) {
+        body {
+          padding-top: 2em;
+        }
+        #title {
+          padding: 1em 0;
+        }
+        h1 {
+          font-size: 24px;
+        }
+        h2 {
+          font-size: 20px;
+          margin-top: -18px; /* provide offset for in-page anchors */
+          padding-top: 38px;
+        }
+        #identifiers dd {
+          max-width: 60%;
+        }
+        #toc {
+          position: fixed;
+          z-index: 2;
+          top: 0;
+          right: 0;
+          padding: 0;
+          margin: 0;
+          background-color: inherit;
+          border-bottom: 1px solid #ccc;
+        }
+        #toc h2 {
+          margin: -1px 0 0 0;
+          padding: 4px 0 4px 6px;
+          padding-right: 1em;
+          min-width: 190px;
+          font-size: 1.1em;
+          text-align: right;
+          background-color: #444;
+          color: white;
+          cursor: pointer;
+        }
+        #toc h2::before {
+          /* css hamburger */
+          float: right;
+          position: relative;
+          width: 1em;
+          height: 1px;
+          left: -164px;
+          margin: 6px 0 0 0;
+          background: white none repeat scroll 0 0;
+          box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+          content: "";
+        }
+        #toc nav {
+          display: none;
+          padding: 0.5em 1em 1em;
+          overflow: auto;
+          height: calc(100vh - 48px);
+          border-left: 1px solid #ddd;
+        }
+      }
 
-/* alternative layout for wide screens */
-@media screen and (min-width: 1024px) {
-  body {
-    max-width: 724px;
-    margin: 42px auto;
-    padding-left: 1.5em;
-    padding-right: 29em;
-  }
-  #toc {
-    position: fixed;
-    top: 42px;
-    right: 42px;
-    width: 25%;
-    margin: 0;
-    padding: 0 1em;
-    z-index: 1;
-  }
-  #toc h2 {
-    border-top: none;
-    border-bottom: 1px solid #ddd;
-    font-size: 1em;
-    font-weight: normal;
-    margin: 0;
-    padding: 0.25em 1em 1em 0;
-  }
-  #toc nav {
-    display: block;
-    height: calc(90vh - 84px);
-    bottom: 0;
-    padding: 0.5em 0 0;
-    overflow: auto;
-  }
-  img { /* future proofing */
-    max-width: 100%;
-    height: auto;
-  }
-}
+      /* alternative layout for wide screens */
+      @media screen and (min-width: 1024px) {
+        body {
+          max-width: 724px;
+          margin: 42px auto;
+          padding-left: 1.5em;
+          padding-right: 29em;
+        }
+        #toc {
+          position: fixed;
+          top: 42px;
+          right: 42px;
+          width: 25%;
+          margin: 0;
+          padding: 0 1em;
+          z-index: 1;
+        }
+        #toc h2 {
+          border-top: none;
+          border-bottom: 1px solid #ddd;
+          font-size: 1em;
+          font-weight: normal;
+          margin: 0;
+          padding: 0.25em 1em 1em 0;
+        }
+        #toc nav {
+          display: block;
+          height: calc(90vh - 84px);
+          bottom: 0;
+          padding: 0.5em 0 0;
+          overflow: auto;
+        }
+        img {
+          /* future proofing */
+          max-width: 100%;
+          height: auto;
+        }
+      }
 
-/* pagination */
-@media print {
-  body {
+      /* pagination */
+      @media print {
+        body {
+          width: 100%;
+        }
+        p {
+          orphans: 3;
+          widows: 3;
+        }
+        #n-copyright-notice {
+          border-bottom: none;
+        }
+        #toc,
+        #n-introduction {
+          page-break-before: always;
+        }
+        #toc {
+          border-top: none;
+          padding-top: 0;
+        }
+        figure,
+        pre {
+          page-break-inside: avoid;
+        }
+        figure {
+          overflow: scroll;
+        }
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+          page-break-after: avoid;
+        }
+        h2 + *,
+        h3 + *,
+        h4 + *,
+        h5 + *,
+        h6 + * {
+          page-break-before: avoid;
+        }
+        pre {
+          white-space: pre-wrap;
+          word-wrap: break-word;
+          font-size: 10pt;
+        }
+        table {
+          border: 1px solid #ddd;
+        }
+        td {
+          border-top: 1px solid #ddd;
+        }
+      }
 
-    width: 100%;
-  }
-  p {
-    orphans: 3;
-    widows: 3;
-  }
-  #n-copyright-notice {
-    border-bottom: none;
-  }
-  #toc, #n-introduction {
-    page-break-before: always;
-  }
-  #toc {
-    border-top: none;
-    padding-top: 0;
-  }
-  figure, pre {
-    page-break-inside: avoid;
-  }
-  figure {
-    overflow: scroll;
-  }
-  h1, h2, h3, h4, h5, h6 {
-    page-break-after: avoid;
-  }
-  h2+*, h3+*, h4+*, h5+*, h6+* {
-    page-break-before: avoid;
-  }
-  pre {
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    font-size: 10pt;
-  }
-  table {
-    border: 1px solid #ddd;
-  }
-  td {
-    border-top: 1px solid #ddd;
-  }
-}
-
-/* This is commented out here, as the string-set: doesn't
+      /* This is commented out here, as the string-set: doesn't
    pass W3C validation currently */
-/*
+      /*
 .ears thead .left {
   string-set: ears-top-left content();
 }
@@ -675,29 +719,29 @@ hr.addr {
 }
 */
 
-@page :first {
-  padding-top: 0;
-  @top-left {
-    content: normal;
-    border: none;
-  }
-  @top-center {
-    content: normal;
-    border: none;
-  }
-  @top-right {
-    content: normal;
-    border: none;
-  }
-}
+      @page :first {
+        padding-top: 0;
+        @top-left {
+          content: normal;
+          border: none;
+        }
+        @top-center {
+          content: normal;
+          border: none;
+        }
+        @top-right {
+          content: normal;
+          border: none;
+        }
+      }
 
-@page {
-  size: A4;
-  margin-bottom: 45mm;
-  padding-top: 20px;
-  /* The follwing is commented out here, but set appropriately by in code, as
+      @page {
+        size: A4;
+        margin-bottom: 45mm;
+        padding-top: 20px;
+        /* The follwing is commented out here, but set appropriately by in code, as
      the content depends on the document */
-  /*
+        /*
   @top-left {
     content: 'Internet-Draft';
     vertical-align: bottom;
@@ -734,832 +778,1765 @@ hr.addr {
       border-top: solid 1px #ccc;
   }
   */
+      }
 
-}
+      /* Changes introduced to fix issues found during implementation */
+      /* Make sure links are clickable even if overlapped by following H* */
+      a {
+        z-index: 2;
+      }
+      /* Separate body from document info even without intervening H1 */
+      section {
+        clear: both;
+      }
 
-/* Changes introduced to fix issues found during implementation */
-/* Make sure links are clickable even if overlapped by following H* */
-a {
-  z-index: 2;
-}
-/* Separate body from document info even without intervening H1 */
-section {
-  clear: both;
-}
+      /* Top align author divs, to avoid names without organization dropping level with org names */
+      .author {
+        vertical-align: top;
+      }
 
+      /* Leave room in document info to show Internet-Draft on one line */
+      #identifiers dt {
+        width: 8em;
+      }
 
-/* Top align author divs, to avoid names without organization dropping level with org names */
-.author {
-  vertical-align: top;
-}
+      /* Don't waste quite as much whitespace between label and value in doc info */
+      #identifiers dd {
+        margin-left: 1em;
+      }
 
-/* Leave room in document info to show Internet-Draft on one line */
-#identifiers dt {
-  width: 8em;
-}
+      /* Give floating toc a background color (needed when it's a div inside section */
+      #toc {
+        background-color: white;
+      }
 
-/* Don't waste quite as much whitespace between label and value in doc info */
-#identifiers dd {
-  margin-left: 1em;
-}
+      /* Make the collapsed ToC header render white on gray also when it's a link */
+      @media screen and (max-width: 1023px) {
+        #toc h2 a,
+        #toc h2 a:link,
+        #toc h2 a:focus,
+        #toc h2 a:hover,
+        #toc a.toplink,
+        #toc a.toplink:hover {
+          color: white;
+          background-color: #444;
+          text-decoration: none;
+        }
+      }
 
-/* Give floating toc a background color (needed when it's a div inside section */
-#toc {
-  background-color: white;
-}
+      /* Give the bottom of the ToC some whitespace */
+      @media screen and (min-width: 1024px) {
+        #toc {
+          padding: 0 0 1em 1em;
+        }
+      }
 
-/* Make the collapsed ToC header render white on gray also when it's a link */
-@media screen and (max-width: 1023px) {
-  #toc h2 a,
-  #toc h2 a:link,
-  #toc h2 a:focus,
-  #toc h2 a:hover,
-  #toc a.toplink,
-  #toc a.toplink:hover {
-    color: white;
-    background-color: #444;
-    text-decoration: none;
-  }
-}
+      /* Style section numbers with more space between number and title */
+      .section-number {
+        padding-right: 0.5em;
+      }
 
-/* Give the bottom of the ToC some whitespace */
-@media screen and (min-width: 1024px) {
-  #toc {
-    padding: 0 0 1em 1em;
-  }
-}
+      /* prevent monospace from becoming overly large */
+      tt,
+      code,
+      pre,
+      code {
+        font-size: 95%;
+      }
 
-/* Style section numbers with more space between number and title */
-.section-number {
-  padding-right: 0.5em;
-}
+      /* Fix the height/width aspect for ascii art*/
+      pre.sourcecode,
+      .art-text pre {
+        line-height: 1.12;
+      }
 
-/* prevent monospace from becoming overly large */
-tt, code, pre, code {
-  font-size: 95%;
-}
+      /* Add styling for a link in the ToC that points to the top of the document */
+      a.toplink {
+        float: right;
+        margin-right: 0.5em;
+      }
 
-/* Fix the height/width aspect for ascii art*/
-pre.sourcecode,
-.art-text pre {
-  line-height: 1.12;
-}
+      /* Fix the dl styling to match the RFC 7992 attributes */
+      dl > dt,
+      dl.dlParallel > dt {
+        float: left;
+        margin-right: 1em;
+      }
+      dl.dlNewline > dt {
+        float: none;
+      }
 
+      /* Provide styling for table cell text alignment */
+      table td.text-left,
+      table th.text-left {
+        text-align: left;
+      }
+      table td.text-center,
+      table th.text-center {
+        text-align: center;
+      }
+      table td.text-right,
+      table th.text-right {
+        text-align: right;
+      }
 
-/* Add styling for a link in the ToC that points to the top of the document */
-a.toplink {
-  float: right;
-  margin-right: 0.5em;
-}
-
-/* Fix the dl styling to match the RFC 7992 attributes */
-dl > dt,
-dl.dlParallel > dt {
-  float: left;
-  margin-right: 1em;
-}
-dl.dlNewline > dt {
-  float: none;
-}
-
-/* Provide styling for table cell text alignment */
-table td.text-left,
-table th.text-left {
-  text-align: left;
-}
-table td.text-center,
-table th.text-center {
-  text-align: center;
-}
-table td.text-right,
-table th.text-right {
-  text-align: right;
-}
-
-/* Make the alternative author contact informatio look less like just another
+      /* Make the alternative author contact informatio look less like just another
    author, and group it closer with the primary author contact information */
-.alternative-contact {
-  margin: 0.5em 0 0.25em 0;
-}
-address .non-ascii {
-  margin: 0 0 0 2em;
-}
+      .alternative-contact {
+        margin: 0.5em 0 0.25em 0;
+      }
+      address .non-ascii {
+        margin: 0 0 0 2em;
+      }
 
-/* With it being possible to set tables with alignment
+      /* With it being possible to set tables with alignment
   left, center, and right, { width: 100%; } does not make sense */
-table {
-  width: auto;
-}
+      table {
+        width: auto;
+      }
 
-/* Avoid reference text that sits in a block with very wide left margin,
+      /* Avoid reference text that sits in a block with very wide left margin,
    because of a long floating dt label.*/
-.references dd {
-  overflow: visible;
-}
+      .references dd {
+        overflow: visible;
+      }
 
-/* Control caption placement */
-caption {
-  caption-side: bottom;
-}
+      /* Control caption placement */
+      caption {
+        caption-side: bottom;
+      }
 
-/* Limit the width of the author address vcard, so names in right-to-left
+      /* Limit the width of the author address vcard, so names in right-to-left
    script don't end up on the other side of the page. */
 
-address.vcard {
-  max-width: 30em;
-  margin-right: auto;
-}
+      address.vcard {
+        max-width: 30em;
+        margin-right: auto;
+      }
 
-/* For address alignment dependent on LTR or RTL scripts */
-address div.left {
-  text-align: left;
-}
-address div.right {
-  text-align: right;
-}
+      /* For address alignment dependent on LTR or RTL scripts */
+      address div.left {
+        text-align: left;
+      }
+      address div.right {
+        text-align: right;
+      }
 
-/* Provide table alignment support.  We can't use the alignX classes above
+      /* Provide table alignment support.  We can't use the alignX classes above
    since they do unwanted things with caption and other styling. */
-table.right {
- margin-left: auto;
- margin-right: 0;
-}
-table.center {
- margin-left: auto;
- margin-right: auto;
-}
-table.left {
- margin-left: 0;
- margin-right: auto;
-}
+      table.right {
+        margin-left: auto;
+        margin-right: 0;
+      }
+      table.center {
+        margin-left: auto;
+        margin-right: auto;
+      }
+      table.left {
+        margin-left: 0;
+        margin-right: auto;
+      }
 
-/* Give the table caption label the same styling as the figcaption */
-caption a[href] {
-  color: #222;
-}
+      /* Give the table caption label the same styling as the figcaption */
+      caption a[href] {
+        color: #222;
+      }
 
-@media print {
-  .toplink {
-    display: none;
-  }
+      @media print {
+        .toplink {
+          display: none;
+        }
 
-  /* avoid overwriting the top border line with the ToC header */
-  #toc {
-    padding-top: 1px;
-  }
+        /* avoid overwriting the top border line with the ToC header */
+        #toc {
+          padding-top: 1px;
+        }
 
-  /* Avoid page breaks inside dl and author address entries */
-  .vcard {
-    page-break-inside: avoid;
-  }
-
-}
-/* Avoid wrapping of URLs in references */
-@media screen {
-  .references a {
-    white-space: nowrap;
-  }
-}
-/* Tweak the bcp14 keyword presentation */
-.bcp14 {
-  font-variant: small-caps;
-  font-weight: bold;
-  font-size: 0.9em;
-}
-/* Tweak the invisible space above H* in order not to overlay links in text above */
- h2 {
-  margin-top: -18px;  /* provide offset for in-page anchors */
-  padding-top: 31px;
- }
- h3 {
-  margin-top: -18px;  /* provide offset for in-page anchors */
-  padding-top: 24px;
- }
- h4 {
-  margin-top: -18px;  /* provide offset for in-page anchors */
-  padding-top: 24px;
- }
-/* Float artwork pilcrow to the right */
-@media screen {
-  .artwork a.pilcrow {
-    display: block;
-    line-height: 0.7;
-    margin-top: 0.15em;
-  }
-}
-/* Make pilcrows on dd visible */
-@media screen {
-  dd:hover > a.pilcrow {
-    visibility: visible;
-  }
-}
-/* Make the placement of figcaption match that of a table's caption
+        /* Avoid page breaks inside dl and author address entries */
+        .vcard {
+          page-break-inside: avoid;
+        }
+      }
+      /* Avoid wrapping of URLs in references */
+      @media screen {
+        .references a {
+          white-space: nowrap;
+        }
+      }
+      /* Tweak the bcp14 keyword presentation */
+      .bcp14 {
+        font-variant: small-caps;
+        font-weight: bold;
+        font-size: 0.9em;
+      }
+      /* Tweak the invisible space above H* in order not to overlay links in text above */
+      h2 {
+        margin-top: -18px; /* provide offset for in-page anchors */
+        padding-top: 31px;
+      }
+      h3 {
+        margin-top: -18px; /* provide offset for in-page anchors */
+        padding-top: 24px;
+      }
+      h4 {
+        margin-top: -18px; /* provide offset for in-page anchors */
+        padding-top: 24px;
+      }
+      /* Float artwork pilcrow to the right */
+      @media screen {
+        .artwork a.pilcrow {
+          display: block;
+          line-height: 0.7;
+          margin-top: 0.15em;
+        }
+      }
+      /* Make pilcrows on dd visible */
+      @media screen {
+        dd:hover > a.pilcrow {
+          visibility: visible;
+        }
+      }
+      /* Make the placement of figcaption match that of a table's caption
    by removing the figure's added bottom margin */
-.alignLeft.art-text,
-.alignCenter.art-text,
-.alignRight.art-text {
-   margin-bottom: 0;
-}
-.alignLeft,
-.alignCenter,
-.alignRight {
-  margin: 1em 0 0 0;
-}
-/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+      .alignLeft.art-text,
+      .alignCenter.art-text,
+      .alignRight.art-text {
+        margin-bottom: 0;
+      }
+      .alignLeft,
+      .alignCenter,
+      .alignRight {
+        margin: 1em 0 0 0;
+      }
+      /* In print, the pilcrow won't show on hover, so prevent it from taking up space,
    possibly even requiring a new line */
-@media print {
-  a.pilcrow {
-    display: none;
-  }
-}
-/* Styling for the external metadata */
-div#external-metadata {
-  background-color: #eee;
-  padding: 0.5em;
-  margin-bottom: 0.5em;
-  display: none;
-}
-div#internal-metadata {
-  padding: 0.5em;                       /* to match the external-metadata padding */
-}
-/* Styling for title RFC Number */
-h1#rfcnum {
-  clear: both;
-  margin: 0 0 -1em;
-  padding: 1em 0 0 0;
-}
-/* Make .olPercent look the same as <ol><li> */
-dl.olPercent > dd {
-  margin: 0 0 0.25em 0;
-  min-height: initial;
-}
-/* Give aside some styling to set it apart */
-aside {
-  border-left: 1px solid #ddd;
-  margin: 1em 0 1em 2em;
-  padding: 0.2em 2em;
-}
-aside > dl,
-aside > ol,
-aside > ul,
-aside > table,
-aside > p {
-  margin-bottom: 0.5em;
-}
-/* Additional page break settings */
-@media print {
-  figcaption, table caption {
-    page-break-before: avoid;
-  }
-}
-/* Font size adjustments for print */
-@media print {
-  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
-  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
-  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
-  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
-  h4    { font-size: 1em;       padding-top: 1.5em; }
-  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
-}
-/* Sourcecode margin in print, when there's no pilcrow */
-@media print {
-  .artwork,
-  .sourcecode {
-    margin-bottom: 1em;
-  }
-}
-/*
+      @media print {
+        a.pilcrow {
+          display: none;
+        }
+      }
+      /* Styling for the external metadata */
+      div#external-metadata {
+        background-color: #eee;
+        padding: 0.5em;
+        margin-bottom: 0.5em;
+        display: none;
+      }
+      div#internal-metadata {
+        padding: 0.5em; /* to match the external-metadata padding */
+      }
+      /* Styling for title RFC Number */
+      h1#rfcnum {
+        clear: both;
+        margin: 0 0 -1em;
+        padding: 1em 0 0 0;
+      }
+      /* Make .olPercent look the same as <ol><li> */
+      dl.olPercent > dd {
+        margin: 0 0 0.25em 0;
+        min-height: initial;
+      }
+      /* Give aside some styling to set it apart */
+      aside {
+        border-left: 1px solid #ddd;
+        margin: 1em 0 1em 2em;
+        padding: 0.2em 2em;
+      }
+      aside > dl,
+      aside > ol,
+      aside > ul,
+      aside > table,
+      aside > p {
+        margin-bottom: 0.5em;
+      }
+      /* Additional page break settings */
+      @media print {
+        figcaption,
+        table caption {
+          page-break-before: avoid;
+        }
+      }
+      /* Font size adjustments for print */
+      @media print {
+        body {
+          font-size: 10pt;
+          line-height: normal;
+          max-width: 96%;
+        }
+        h1 {
+          font-size: 1.72em;
+          padding-top: 1.5em;
+        } /* 1*1.2*1.2*1.2 */
+        h2 {
+          font-size: 1.44em;
+          padding-top: 1.5em;
+        } /* 1*1.2*1.2 */
+        h3 {
+          font-size: 1.2em;
+          padding-top: 1.5em;
+        } /* 1*1.2 */
+        h4 {
+          font-size: 1em;
+          padding-top: 1.5em;
+        }
+        h5,
+        h6 {
+          font-size: 1em;
+          margin: initial;
+          padding: 0.5em 0 0.3em;
+        }
+      }
+      /* Sourcecode margin in print, when there's no pilcrow */
+      @media print {
+        .artwork,
+        .sourcecode {
+          margin-bottom: 1em;
+        }
+      }
+      /*
   The margin-left: 0 on <dd> removes all distinction
   between levels from nested <dl>s.  Undo that.
 */
-dl.olPercent > dd,
-dd {
-  margin-left: revert;
-}
-/* Avoid narrow tables forcing too narrow table captions, which may render badly */
-table {
-  min-width: 20em;
-}
-/* ol type a */
-ol.type-a { list-style-type: lower-alpha; }
-ol.type-A { list-style-type: upper-alpha; }
-ol.type-i { list-style-type: lower-roman; }
-ol.type-I { list-style-type: lower-roman; }
-/* Apply the print table and row borders in general, on request from the RPC,
+      dl.olPercent > dd,
+      dd {
+        margin-left: revert;
+      }
+      /* Avoid narrow tables forcing too narrow table captions, which may render badly */
+      table {
+        min-width: 20em;
+      }
+      /* ol type a */
+      ol.type-a {
+        list-style-type: lower-alpha;
+      }
+      ol.type-A {
+        list-style-type: upper-alpha;
+      }
+      ol.type-i {
+        list-style-type: lower-roman;
+      }
+      ol.type-I {
+        list-style-type: lower-roman;
+      }
+      /* Apply the print table and row borders in general, on request from the RPC,
 and increase the contrast between border and odd row background sligthtly */
-table {
-  border: 1px solid #ddd;
-}
-td {
-  border-top: 1px solid #ddd;
-}
-tr:nth-child(2n+1) > td {
-  background-color: #f8f8f8;
-}
-/* Use style rules to govern display of the TOC. */
-@media screen and (max-width: 1023px) {
-  #toc nav { display: none; }
-  #toc.active nav { display: block; }
-}
-</style>
-<link href="rfc-local.css" rel="stylesheet" type="text/css">
-</head>
-<body>
-<script src="metadata.min.js"></script>
-<table class="ears">
-<thead><tr>
-<td class="left"></td>
-<td class="center">OBB-CERT-1-ID1</td>
-<td class="right">May 2021</td>
-</tr></thead>
-<tfoot><tr>
-<td class="left">Rodrigues, et al.</td>
-<td class="center">Standards Track</td>
-<td class="right">[Page]</td>
-</tr></tfoot>
-</table>
-<div id="external-metadata" class="document-information"></div>
-<div id="internal-metadata" class="document-information">
-<dl id="identifiers">
-<dt class="label-workgroup">Workgroup:</dt>
-<dd class="workgroup">Open Banking Brasil GT Security</dd>
-<dt class="label-internet-draft">Internet-Draft:</dt>
-<dd class="internet-draft">open-banking-brasil-certificate-standards-1_ID1</dd>
-<dt class="label-published">Published:</dt>
-<dd class="published">
-<time datetime="2021-05-20" class="published">20 May 2021</time>
-    </dd>
-<dt class="label-intended-status">Intended Status:</dt>
-<dd class="intended-status">Standards Track</dd>
-<dt class="label-authors">Authors:</dt>
-<dd class="authors">
-<div class="author">
-      <div class="author-name">M. Rodrigues</div>
-<div class="org">Itau</div>
-</div>
-<div class="author">
-      <div class="author-name">J. Dias</div>
-<div class="org">Banco Pan</div>
-</div>
-<div class="author">
-      <div class="author-name">GT. Security</div>
-<div class="org">OBBIS</div>
-</div>
-</dd>
-</dl>
-</div>
-<h1 id="title">Open Banking Brasil Certificate Standards 1.0 Implementers Draft 1</h1>
-<section class="note" id="section-note.1">
+      table {
+        border: 1px solid #ddd;
+      }
+      td {
+        border-top: 1px solid #ddd;
+      }
+      tr:nth-child(2n + 1) > td {
+        background-color: #f8f8f8;
+      }
+      /* Use style rules to govern display of the TOC. */
+      @media screen and (max-width: 1023px) {
+        #toc nav {
+          display: none;
+        }
+        #toc.active nav {
+          display: block;
+        }
+      }
+    </style>
+    <link href="rfc-local.css" rel="stylesheet" type="text/css" />
+  </head>
+  <body>
+    <script src="metadata.min.js"></script>
+    <table class="ears">
+      <thead>
+        <tr>
+          <td class="left"></td>
+          <td class="center">OBB-CERT-1-ID1</td>
+          <td class="right">May 2021</td>
+        </tr>
+      </thead>
+      <tfoot>
+        <tr>
+          <td class="left">Rodrigues, et al.</td>
+          <td class="center">Standards Track</td>
+          <td class="right">[Page]</td>
+        </tr>
+      </tfoot>
+    </table>
+    <div id="external-metadata" class="document-information"></div>
+    <div id="internal-metadata" class="document-information">
+      <dl id="identifiers">
+        <dt class="label-workgroup">Workgroup:</dt>
+        <dd class="workgroup">Open Banking Brasil GT Security</dd>
+        <dt class="label-internet-draft">Internet-Draft:</dt>
+        <dd class="internet-draft">
+          open-banking-brasil-certificate-standards-1_ID1
+        </dd>
+        <dt class="label-published">Published:</dt>
+        <dd class="published">
+          <time datetime="2021-05-27" class="published">27 May 2021</time>
+        </dd>
+        <dt class="label-intended-status">Intended Status:</dt>
+        <dd class="intended-status">Standards Track</dd>
+        <dt class="label-authors">Authors:</dt>
+        <dd class="authors">
+          <div class="author">
+            <div class="author-name">M. Rodrigues</div>
+            <div class="org">Itau</div>
+          </div>
+          <div class="author">
+            <div class="author-name">J. Dias</div>
+            <div class="org">Banco Pan</div>
+          </div>
+          <div class="author">
+            <div class="author-name">GT. Security</div>
+            <div class="org">OBBIS</div>
+          </div>
+        </dd>
+      </dl>
+    </div>
+    <h1 id="title">
+      Open Banking Brasil Certificate Standards 1.0 Implementers Draft 1
+    </h1>
+    <section class="note" id="section-note.1">
       <h2 id="name-pref225cio">
-<a href="#name-pref225cio" class="section-name selfRef">Pref&#225;cio</a>
+        <a href="#name-pref225cio" class="section-name selfRef"
+          >Pref&#225;cio</a
+        >
       </h2>
-<p id="section-note.1-1">A Estrutura Inicial do Open Banking Brasil &#233; respons&#225;vel por criar padr&#245;es e especifica&#231;&#245;es necess&#225;rias para garantir que os requisitos e obriga&#231;&#245;es da Regula&#231;&#245;es do Open Banking Brasil como originalmente publicadas pelo Banco Central do Brasil. &#201; poss&#237;vel que parte dos elementos deste documento estejam sujeitos a direitos autorais.  A Estrutura Inicial do Open Banking Brasil n&#227;o deve ser respons&#225;vel por identificar nenhuma parte ou totalidade destes direitos autorais.<a href="#section-note.1-1" class="pilcrow">¶</a></p>
-</section>
-<section class="note" id="section-note.2">
+      <p id="section-note.1-1">
+        A Estrutura Inicial do Open Banking Brasil &#233; respons&#225;vel por
+        criar padr&#245;es e especifica&#231;&#245;es necess&#225;rias para
+        garantir que os requisitos e obriga&#231;&#245;es da
+        Regula&#231;&#245;es do Open Banking Brasil como originalmente
+        publicadas pelo Banco Central do Brasil. &#201; poss&#237;vel que parte
+        dos elementos deste documento estejam sujeitos a direitos autorais. A
+        Estrutura Inicial do Open Banking Brasil n&#227;o deve ser
+        respons&#225;vel por identificar nenhuma parte ou totalidade destes
+        direitos autorais.<a href="#section-note.1-1" class="pilcrow">¶</a>
+      </p>
+    </section>
+    <section class="note" id="section-note.2">
       <h2 id="name-objetivo">
-<a href="#name-objetivo" class="section-name selfRef">Objetivo</a>
+        <a href="#name-objetivo" class="section-name selfRef">Objetivo</a>
       </h2>
-<p id="section-note.2-1">Especificar o conjunto de certificados necess&#225;rios para o Open Banking Brasil s&#227;o padr&#245;es de certificados que devem ser utilizados por seus participantes para garantir interoperabilidade para autentica&#231;&#227;o, confidencialidade, integridade e n&#227;o rep&#250;dio entre as entidades participantes do Open Banking Brasil, bem como para os usu&#225;rios e consumidores destas entidades. O p&#250;blico desta especifica&#231;&#227;o s&#227;o entidades que s&#227;o participantes do Open Banking Brasil e necessitam fazer a emiss&#227;o de certificados para autenticar junto a outras entidades bem como oferecer a seus clientes um canal de autentica&#231;&#227;o seguro.<a href="#section-note.2-1" class="pilcrow">¶</a></p>
-</section>
-<section class="note" id="section-note.3">
+      <p id="section-note.2-1">
+        Especificar o conjunto de certificados necess&#225;rios para o Open
+        Banking Brasil s&#227;o padr&#245;es de certificados que devem ser
+        utilizados por seus participantes para garantir interoperabilidade para
+        autentica&#231;&#227;o, confidencialidade, integridade e n&#227;o
+        rep&#250;dio entre as entidades participantes do Open Banking Brasil,
+        bem como para os usu&#225;rios e consumidores destas entidades. O
+        p&#250;blico desta especifica&#231;&#227;o s&#227;o entidades que
+        s&#227;o participantes do Open Banking Brasil e necessitam fazer a
+        emiss&#227;o de certificados para autenticar junto a outras entidades
+        bem como oferecer a seus clientes um canal de autentica&#231;&#227;o
+        seguro.<a href="#section-note.2-1" class="pilcrow">¶</a>
+      </p>
+    </section>
+    <section class="note" id="section-note.3">
       <h2 id="name-conven231245es-notacionais">
-<a href="#name-conven231245es-notacionais" class="section-name selfRef">Conven&#231;&#245;es Notacionais</a>
+        <a href="#name-conven231245es-notacionais" class="section-name selfRef"
+          >Conven&#231;&#245;es Notacionais</a
+        >
       </h2>
-<p id="section-note.3-1">As palavras-chave "deve", "n&#227;o deve", "recomenda", "n&#227;o recomenda", "pode" e "pode" neste documento devem ser interpretadas conforme descrito na [Diretiva ISO Parte 2] [ISODIR2]. Essas palavras-chave n&#227;o s&#227;o usadas como termos de dicion&#225;rio, de forma que qualquer ocorr&#234;ncia delas deve ser interpretada como palavras-chave e n&#227;o devem ser interpretadas com seus significados em linguagem natural.<a href="#section-note.3-1" class="pilcrow">¶</a></p>
-</section>
-<div id="toc">
-<section id="section-toc.1">
-        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
-<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+      <p id="section-note.3-1">
+        As palavras-chave "deve", "n&#227;o deve", "recomenda", "n&#227;o
+        recomenda", "pode" e "pode" neste documento devem ser interpretadas
+        conforme descrito na [Diretiva ISO Parte 2] [ISODIR2]. Essas
+        palavras-chave n&#227;o s&#227;o usadas como termos de dicion&#225;rio,
+        de forma que qualquer ocorr&#234;ncia delas deve ser interpretada como
+        palavras-chave e n&#227;o devem ser interpretadas com seus significados
+        em linguagem natural.<a href="#section-note.3-1" class="pilcrow">¶</a>
+      </p>
+    </section>
+    <div id="toc">
+      <section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a>
+        <h2 id="name-table-of-contents">
+          <a href="#name-table-of-contents" class="section-name selfRef"
+            >Table of Contents</a
+          >
         </h2>
-<nav class="toc"><ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.1">
-            <p id="section-toc.1-1.1.1"><a href="#section-1" class="xref">1</a>.  <a href="#name-escopo" class="xref">Escopo</a><a href="#section-toc.1-1.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.2">
-            <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-refer234ncias-normativas" class="xref">Refer&#234;ncias Normativas</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-termos-e-definicoes" class="xref">Termos e Definicoes</a><a href="#section-toc.1-1.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-glossario" class="xref">Glossario</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-padrao-de-certificados-open" class="xref">Padrao de Certificados Open Banking Brasil</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.5.2.1">
-                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="xref">5.1</a>.  <a href="#name-introducao" class="xref">Introducao</a><a href="#section-toc.1-1.5.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.5.2.2">
-                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="xref">5.2</a>.  <a href="#name-certificados-icp-brasil" class="xref">Certificados ICP-Brasil</a><a href="#section-toc.1-1.5.2.2.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.5.2.2.2.1">
-                    <p id="section-toc.1-1.5.2.2.2.1.1"><a href="#section-5.2.1" class="xref">5.2.1</a>.  <a href="#name-certificado-servidor" class="xref">Certificado Servidor</a><a href="#section-toc.1-1.5.2.2.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.5.2.2.2.2">
-                    <p id="section-toc.1-1.5.2.2.2.2.1"><a href="#section-5.2.2" class="xref">5.2.2</a>.  <a href="#name-certificado-cliente" class="xref">Certificado Cliente</a><a href="#section-toc.1-1.5.2.2.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.5.2.2.2.3">
-                    <p id="section-toc.1-1.5.2.2.2.3.1"><a href="#section-5.2.3" class="xref">5.2.3</a>.  <a href="#name-certificado-de-assinatura" class="xref">Certificado de Assinatura</a><a href="#section-toc.1-1.5.2.2.2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.5.2.2.2.4">
-                    <p id="section-toc.1-1.5.2.2.2.4.1"><a href="#section-5.2.4" class="xref">5.2.4</a>.  <a href="#name-certificado-para-front-end" class="xref">Certificado para Front-End</a><a href="#section-toc.1-1.5.2.2.2.4.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-</ul>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-reconhecimento" class="xref">Reconhecimento</a><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-informativo" class="xref">Informativo</a><a href="#section-toc.1-1.7.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-apendice" class="xref">Apendice</a><a href="#section-toc.1-1.8.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.8.2.1">
-                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-modelo-de-configuracao-de-c" class="xref">Modelo de Configuracao de Certificado Cliente - OpenSSL</a><a href="#section-toc.1-1.8.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.8.2.2">
-                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="xref">8.2</a>.  <a href="#name-modelo-de-configuracao-de-ce" class="xref">Modelo de Configuracao de Certificado de Assinatura - OpenSSL</a><a href="#section-toc.1-1.8.2.2.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</li>
-</ul>
-</nav>
-</section>
-</div>
-<div id="escopo">
-<section id="section-1">
-      <h2 id="name-escopo">
-<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-escopo" class="section-name selfRef">Escopo</a>
-      </h2>
-<p id="section-1-1">Este documento especifica os tipos de certificados necess&#225;rios para:<a href="#section-1-1" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-1-2.1">
-          <p id="section-1-2.1.1">Autenticar mutuamente (MTLS - Mutual - TLS) as aplica&#231;&#245;es dos participantes;<a href="#section-1-2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-1-2.2">
-          <p id="section-1-2.2.1">Assinatura de Mensagens (JWS - JSON Web Signature) de aplica&#231;&#245;es para garantir a autenticidade e n&#227;o rep&#250;dio de mensagens entre os participantes;<a href="#section-1-2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-1-2.3">
-          <p id="section-1-2.3.1">Apresentar um canal seguro e confi&#225;vel para clientes do Open Banking Brasil;<a href="#section-1-2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-1-2.4">
-          <p id="section-1-2.4.1">Autenticar participantes junto do Diret&#243;rio de participantes do Open Banking Brasil.<a href="#section-1-2.4.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</section>
-</div>
-<div id="References">
-<section id="section-2">
-      <h2 id="name-refer234ncias-normativas">
-<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-refer234ncias-normativas" class="section-name selfRef">Refer&#234;ncias Normativas</a>
-      </h2>
-<p id="section-2-1">Os seguintes documentos referenciados s&#227;o indispens&#225;veis para a aplica&#231;&#227;o deste documento. Para refer&#234;ncias datadas, apenas a edi&#231;&#227;o citada se aplica. Para refer&#234;ncias n&#227;o datadas, a &#250;ltima edi&#231;&#227;o do documento referenciado (incluindo quaisquer emendas) se aplica.<a href="#section-2-1" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-2-2.1">
-          <p id="section-2-2.1.1">[ISODIR2] - ISO/IEC Directives Part 2 [ISODIR2]: <a href="https://www.iso.org/sites/directives/current/part2/index.xhtml">https://www.iso.org/sites/directives/current/part2/index.xhtml</a><a href="#section-2-2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.2">
-          <p id="section-2-2.2.1">[RFC5280] -  Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile: <a href="https://datatracker.ietf.org/doc/html/rfc5280">https://datatracker.ietf.org/doc/html/rfc5280</a><a href="#section-2-2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.3">
-          <p id="section-2-2.3.1">[RFC7519] - JSON Web Token (JWT) [RFC7519]:<a href="https://tools.ietf.org/html/rfc7519">https://tools.ietf.org/html/rfc7519</a><a href="#section-2-2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.4">
-          <p id="section-2-2.4.1">[RFC7515] - JSON Web Signature (JWS) [RFC7515] :<a href="https://datatracker.ietf.org/doc/html/rfc7515">https://datatracker.ietf.org/doc/html/rfc7515</a><a href="#section-2-2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.5">
-          <p id="section-2-2.5.1">[RFC7591] - OAuth 2.0 Dynamic Client Registration Protocol [RFC7591]:<a href="https://tools.ietf.org/html/rfc7591">https://tools.ietf.org/html/rfc7591</a><a href="#section-2-2.5.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.6">
-          <p id="section-2-2.6.1">[RFC7592] - OAuth 2.0 Dynamic Client Registration Management Protocol [RFC7592]:<a href="https://tools.ietf.org/html/rfc7592">https://tools.ietf.org/html/rfc7592</a><a href="#section-2-2.6.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.7">
-          <p id="section-2-2.7.1">[BCP195] - Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS) [BCP195]: <a href="https://tools.ietf.org/html/bcp195">https://tools.ietf.org/html/bcp195</a><a href="#section-2-2.7.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.8">
-          <p id="section-2-2.8.1">[RFC8705] - OAuth 2.0 Mutual TLS Client Authentication and Certificate Bound Access Tokens [RFC8705]: <a href="https://tools.ietf.org/html/rfc8705">https://tools.ietf.org/html/rfc8705</a><a href="#section-2-2.8.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.9">
-          <p id="section-2-2.9.1">[OBB-FAPI] - Open Banking Brasil Financial-grade API Security Profile 1.0 [OBB-FAPI]: <a href="https://github.com/OpenBanking-Brasil/specs-seguranca/open-banking-brasil-financial-api-1_ID1.html">https://github.com/OpenBanking-Brasil/specs-seguranca/open-banking-brasil-financial-api-1_ID1.html</a><a href="#section-2-2.9.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.10">
-          <p id="section-2-2.10.1">[DOC-ICP-01] - DECLARA&#199;&#195;O DE PR&#193;TICAS DE CERTIFICA&#199;&#195;O DA AUTORIDADE CERTIFICADORA RAIZ DA ICP-BRASIL: <a href="https://www.gov.br/iti/pt-br/centrais-de-conteudo/doc-icp-01-v-5-2-dpc-da-ac-raiz-da-icp-brasil-pdf">https://www.gov.br/iti/pt-br/centrais-de-conteudo/doc-icp-01-v-5-2-dpc-da-ac-raiz-da-icp-brasil-pdf</a><a href="#section-2-2.10.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.11">
-          <p id="section-2-2.11.1">[RFC6749] - The OAuth 2.0 Authorization Framework [RFC6749]: <a href="https://tools.ietf.org/html/rfc6749">https://tools.ietf.org/html/rfc6749</a><a href="#section-2-2.11.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.12">
-          <p id="section-2-2.12.1">[BCB-IN99] - Manual de Seguran&#231;a do Open Banking: <a href="https://www.in.gov.br/en/web/dou/-/instrucao-normativa-bcb-n-99-de-14-de-abril-de-2021-314641007">https://www.in.gov.br/en/web/dou/-/instrucao-normativa-bcb-n-99-de-14-de-abril-de-2021-314641007</a><a href="#section-2-2.12.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-2-2.13">
-          <p id="section-2-2.13.1">[RFC2818] - HTTP Over TLS: <a href="https://datatracker.ietf.org/doc/html/rfc2818">https://datatracker.ietf.org/doc/html/rfc2818</a><a href="#section-2-2.13.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</section>
-</div>
-<div id="termos-e-definicoes">
-<section id="section-3">
-      <h2 id="name-termos-e-definicoes">
-<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-termos-e-definicoes" class="section-name selfRef">Termos e Definicoes</a>
-      </h2>
-<p id="section-3-1">Para o prop&#243;sito deste documento os termos definidos na [RFC5280, [BCP195], [RFC8705], e ISO29100 s&#227;o aplic&#225;veis.<a href="#section-3-1" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="glossario">
-<section id="section-4">
-      <h2 id="name-glossario">
-<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-glossario" class="section-name selfRef">Glossario</a>
-      </h2>
-<ul>
-<li id="section-4-1.1">
-          <p id="section-4-1.1.1"><strong>SSA</strong> - Software Statement Assertion<a href="#section-4-1.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4-1.2">
-          <p id="section-4-1.2.1"><strong>SS</strong> - Software Statement<a href="#section-4-1.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4-1.3">
-          <p id="section-4-1.3.1"><strong>DCR</strong> - Dynamic Client Registration<a href="#section-4-1.3.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4-1.4">
-          <p id="section-4-1.4.1"><strong>API</strong> - Application Programming Interface<a href="#section-4-1.4.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4-1.5">
-          <p id="section-4-1.5.1"><strong>HTTP</strong> - Hyper Text Transfer Protocol<a href="#section-4-1.5.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4-1.6">
-          <p id="section-4-1.6.1"><strong>TLS</strong> - Transport Layer Security<a href="#section-4-1.6.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4-1.7">
-          <p id="section-4-1.7.1"><strong>mTLS</strong> - Mutual Transport Layer Security<a href="#section-4-1.7.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4-1.8">
-          <p id="section-4-1.8.1"><strong>ICP</strong> - Infraestrutura de Chave P&#250;blicas Brasileira<a href="#section-4-1.8.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</section>
-</div>
-<div id="padrao-de-certificados-open-banking-brasil">
-<section id="section-5">
-      <h2 id="name-padrao-de-certificados-open">
-<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-padrao-de-certificados-open" class="section-name selfRef">Padrao de Certificados Open Banking Brasil</a>
-      </h2>
-<div id="introducao">
-<section id="section-5.1">
-        <h3 id="name-introducao">
-<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-introducao" class="section-name selfRef">Introducao</a>
-        </h3>
-<p id="section-5.1-1">O sistema de Open Banking Brasil faz uso de cadeias de certificados e protocolo TLS para garantir a confidencialidade, autentica&#231;&#227;o e integridade do canal de comunica&#231;&#227;o utilizado pelas APIs das institui&#231;&#245;es participantes do Ecossistema bem como dos clientes de cada um dos participantes.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
-<p id="section-5.1-2">Os certificados utilizados para o Open Banking Brasil tamb&#233;m s&#227;o necess&#225;rios para autenticar as aplica&#231;&#245;es atrav&#233;s do oAuth 2.0 mTLS ou private<em>key</em>jwt, al&#233;m de tamb&#233; servirem para realizar a assinatura de payload pelo uso de JWS. Outra atribui&#231;&#227;o importante dos certificados &#233; realizar a autentica&#231;&#227;o e apresentar um canal seguro para o consumidor final no ato de autentica&#231;&#227;o e uso dos servi&#231;os prestados pela entidade participante.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="certificados-icp-brasil">
-<section id="section-5.2">
-        <h3 id="name-certificados-icp-brasil">
-<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-certificados-icp-brasil" class="section-name selfRef">Certificados ICP-Brasil</a>
-        </h3>
-<p id="section-5.2-1">Os certificados emitidos junto a Autoridades Certificadoras autorizadas pelo ICP-Brasil s&#227;o utilizados apenas na comunica&#231;&#227;o entre as entidades participantes do ecossistema do Open Banking Brasil.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
-<p id="section-5.2-2">Os processos de emiss&#227;o e revoga&#231;&#227;o dos certificados s&#227;o de responsabilidade das pr&#243;prias Autoridades Certificadores, sendo regulamentados por Declara&#231;&#245;es de Pr&#225;tica de Certifica&#231;&#227;o, e supervisionadas pelo Comit&#234; Gestor da Infraestrutura de Chaves P&#250;blicas Brasileira.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
-<p id="section-5.2-3">As pr&#225;ticas, processos, disponibiliza&#231;&#227;o e valores praticados pelas Autoridades Certificadoras n&#227;o s&#227;o de responsabilidade do Estrutura Inicial do Open Banking Brasil.<a href="#section-5.2-3" class="pilcrow">¶</a></p>
-<p id="section-5.2-4"><strong>Algoritmos</strong><a href="#section-5.2-4" class="pilcrow">¶</a></p>
-<p id="section-5.2-5">Todos os certificados emitidos junto ao ICP-Brasil devem possuir as seguintes caracter&#237;sticas:<a href="#section-5.2-5" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-5.2-6.1">
-            <p id="section-5.2-6.1.1">Tipo A do ICP-Brasil;<a href="#section-5.2-6.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2-6.2">
-            <p id="section-5.2-6.2.1">Algoritmo de Chaves: RSA 2048 bits;<a href="#section-5.2-6.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2-6.3">
-            <p id="section-5.2-6.3.1">Message Digest: SHA 256 bits.<a href="#section-5.2-6.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-<div id="certificado-servidor">
-<section id="section-5.2.1">
-          <h4 id="name-certificado-servidor">
-<a href="#section-5.2.1" class="section-number selfRef">5.2.1. </a><a href="#name-certificado-servidor" class="section-name selfRef">Certificado Servidor</a>
-          </h4>
-<p id="section-5.2.1-1">O Certificado Servidor deve ser emitido para proteger e autenticar o canal TLS utilizado pelas APIs que ser&#227;o consumidas pelas aplica&#231;&#245;es cliente de entidades participantes do Open Banking.<a href="#section-5.2.1-1" class="pilcrow">¶</a></p>
-<p id="section-5.2.1-2">O padr&#227;o de certificado utilizado deve seguir as pr&#225;ticas de emiss&#227;o de certificados existentes de "CERTIFICADO PARA SERVIDOR WEB - ICP-Brasil".<a href="#section-5.2.1-2" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="certificado-cliente">
-<section id="section-5.2.2">
-          <h4 id="name-certificado-cliente">
-<a href="#section-5.2.2" class="section-number selfRef">5.2.2. </a><a href="#name-certificado-cliente" class="section-name selfRef">Certificado Cliente</a>
-          </h4>
-<p id="section-5.2.2-1">Os certificados de Open Banking, denominados Certificado de Aplica&#231;&#227;o Cliente (Transporte) s&#227;o utilizados para autenticar o canal MTLS.  Os Certificado Cliente tamb&#233;m s&#227;o utilizados para realizar a autentica&#231;&#227;o da aplica&#231;&#227;o cliente atrav&#233;s de oAuth 2.0 mTLS ou private<em>key</em>jwt, de acordo com cadastro da aplica&#231;&#227;o realizado o processo de Dynamic Client Registration junto a entidade transmissora.<a href="#section-5.2.2-1" class="pilcrow">¶</a></p>
-<p id="section-5.2.2-2">Para emiss&#227;o de certificado de cliente &#233; necess&#225;rio que a institui&#231;&#227;o participante do Open Banking Brasil tenha realizado o cadastro de aplica&#231;&#227;o ao diret&#243;rio, atrav&#233;s da emiss&#227;o de Software Statement Assertion, e com isso j&#225; tenha obtido o valor de Software Statement ID.<a href="#section-5.2.2-2" class="pilcrow">¶</a></p>
-<div id="atributos-openbanking-brasil">
-<section id="section-5.2.2.1">
-            <h5 id="name-atributos-openbanking-brasi">
-<a href="#section-5.2.2.1" class="section-number selfRef">5.2.2.1. </a><a href="#name-atributos-openbanking-brasi" class="section-name selfRef">Atributos OpenBanking Brasil</a>
-            </h5>
-<ul>
-<li id="section-5.2.2.1-1.1">
-                <p id="section-5.2.2.1-1.1.1"><strong>serialNumber:</strong> Cadastro Nacional de Pessoal Juridica (CNPJ) da pessoa jur&#237;dica titular do certificado e associado ao atributo UID e Software Statement ID, durante valida&#231;&#227;o junto ao Servi&#231;o de Diret&#243;rio do OpenBanking Brasil;<a href="#section-5.2.2.1-1.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-1.2">
-                <p id="section-5.2.2.1-1.2.1"><strong>organizationalUnitName:</strong> C&#243;digo de Participante associado ao CNPJ listado no Servi&#231;o de Diret&#243;rio do OpenBanking Brasil;<a href="#section-5.2.2.1-1.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-1.3">
-                <p id="section-5.2.2.1-1.3.1"><strong>UID:</strong> Software Statement ID cadastrado no Servi&#231;o de Diret&#243;rio do OpenBanking Brasil e pertencente ao CNPJ e C&#243;digo de Participante.<a href="#section-5.2.2.1-1.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-<p id="section-5.2.2.1-2">O Certificado Cliente deve ser emitido atrav&#233;s de cadeia V10, e deve obrigatoriamente conter os seguintes atributos:<a href="#section-5.2.2.1-2" class="pilcrow">¶</a></p>
-<p id="section-5.2.2.1-3"><strong>Distinguished Name</strong><a href="#section-5.2.2.1-3" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-5.2.2.1-4.1">
-                <p id="section-5.2.2.1-4.1.1"><strong>businessCategory (OID 2.5.4.15):</strong>  Tipo de categoria comercial, devendo conter: "Private Organization" ou "Government Entity" ou "Business Entity" ou "Non-Commercial Entity"<a href="#section-5.2.2.1-4.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-4.2">
-                <p id="section-5.2.2.1-4.2.1"><strong>jurisdictionCountryName (OID: 1.3.6.1.4.1.311.60.2.1.3):</strong> BR<a href="#section-5.2.2.1-4.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-4.3">
-                <p id="section-5.2.2.1-4.3.1"><strong>serialNumber (OID 2.5.4.5):</strong> CNPJ<a href="#section-5.2.2.1-4.3.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-4.4">
-                <p id="section-5.2.2.1-4.4.1"><strong>countryName (OID 2.5.4.6):</strong> BR<a href="#section-5.2.2.1-4.4.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-4.5">
-                <p id="section-5.2.2.1-4.5.1"><strong>organizationName (OID 2.5.4.10):</strong> Raz&#227;o Social<a href="#section-5.2.2.1-4.5.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-4.6">
-                <p id="section-5.2.2.1-4.6.1"><strong>stateOrProvinceName (OID 2.5.4.8):</strong> Unidade da federa&#231;&#227;o do endere&#231;o f&#237;sico do titular do certificado<a href="#section-5.2.2.1-4.6.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-4.7">
-                <p id="section-5.2.2.1-4.7.1"><strong>localityName (OID 2.5.4.7):</strong> Cidade do endere&#231;o f&#237;sico do titular<a href="#section-5.2.2.1-4.7.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-4.8">
-                <p id="section-5.2.2.1-4.8.1"><strong>organizationalUnitName (OID 2.5.4.11):</strong> C&#243;digo de Participante associado ao CNPJ listado no Servi&#231;o de Diret&#243;rio do OpenBanking Brasil<a href="#section-5.2.2.1-4.8.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-4.9">
-                <p id="section-5.2.2.1-4.9.1"><strong>UID (OID 0.9.2342.19200300.100.1.1):</strong> Software Statement ID gerado pelo Diret&#243;rio do Open Banking Brasil<a href="#section-5.2.2.1-4.9.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-4.10">
-                <p id="section-5.2.2.1-4.10.1"><strong>commonName (OID 2.5.4.3):</strong> FQDN ou Wildcard<a href="#section-5.2.2.1-4.10.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-<p id="section-5.2.2.1-5"><strong>Certificate Extensions</strong><a href="#section-5.2.2.1-5" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-5.2.2.1-6.1">
-                <p id="section-5.2.2.1-6.1.1"><strong>keyUsage:</strong> critical,digitalSignature,keyEncipherment<a href="#section-5.2.2.1-6.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2.1-6.2">
-                <p id="section-5.2.2.1-6.2.1"><strong>extendedKeyUsage:</strong> clientAuth<a href="#section-5.2.2.1-6.2.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-<p id="section-5.2.2.1-7"><strong>Subject Alternative Name</strong><a href="#section-5.2.2.1-7" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-5.2.2.1-8.1">
-                <p id="section-5.2.2.1-8.1.1"><strong>dNSName:</strong> FQDN ou Wildcard<a href="#section-5.2.2.1-8.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="certificado-de-assinatura">
-<section id="section-5.2.3">
-          <h4 id="name-certificado-de-assinatura">
-<a href="#section-5.2.3" class="section-number selfRef">5.2.3. </a><a href="#name-certificado-de-assinatura" class="section-name selfRef">Certificado de Assinatura</a>
-          </h4>
-<p id="section-5.2.3-1">Os certificados de Open Banking, denominados Certificado de Assinatura (Assinatura) s&#227;o utilizados para realizar assinatura do payload atrav&#233;s do uso de JWS (JSON Web Signature).<a href="#section-5.2.3-1" class="pilcrow">¶</a></p>
-<div id="atributos-open-banking-brasil-presentes-no-certificado">
-<section id="section-5.2.3.1">
-            <h5 id="name-atributos-open-banking-bras">
-<a href="#section-5.2.3.1" class="section-number selfRef">5.2.3.1. </a><a href="#name-atributos-open-banking-bras" class="section-name selfRef">Atributos Open Banking Brasil presentes no Certificado</a>
-            </h5>
-<ul>
-<li id="section-5.2.3.1-1.1">
-                <p id="section-5.2.3.1-1.1.1"><strong>UID:</strong> C&#243;digo de Participante associado ao CNPJ listado no Servi&#231;o de Diret&#243;rio do OpenBanking Brasil;<a href="#section-5.2.3.1-1.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.3.1-1.2">
-                <p id="section-5.2.3.1-1.2.1"><strong>commonName:</strong> Raz&#227;o Social cadastrado no Servi&#231;o de Diret&#243;rio do OpenBanking Brasil e pertencente ao CNPJ e C&#243;digo de Participante.<a href="#section-5.2.3.1-1.2.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-<p id="section-5.2.3.1-2">O Certificado de Assinatura deve ser emitido atrav&#233;s de cadeia V5, e deve obrigatoriamente conter os seguintes atributos:<a href="#section-5.2.3.1-2" class="pilcrow">¶</a></p>
-<p id="section-5.2.3.1-3"><strong>Distinguished Name</strong><a href="#section-5.2.3.1-3" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-5.2.3.1-4.1">
-                <p id="section-5.2.3.1-4.1.1"><strong>UID (OID 0.9.2342.19200300.100.1.1):</strong>  C&#243;digo de Participante associado ao CNPJ listado no Servi&#231;o de Diret&#243;rio do OpenBanking Brasil<a href="#section-5.2.3.1-4.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.3.1-4.2">
-                <p id="section-5.2.3.1-4.2.1"><strong>countryName (OID 2.5.4.6):</strong> BR<a href="#section-5.2.3.1-4.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.3.1-4.3">
-                <p id="section-5.2.3.1-4.3.1"><strong>organizationName (OID 2.5.4.10):</strong> ICP-Brasil<a href="#section-5.2.3.1-4.3.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.3.1-4.4">
-                <p id="section-5.2.3.1-4.4.1"><strong>organizationalUnitName (OID 2.5.4.11):</strong> Nome da Autoridade Certificadora<a href="#section-5.2.3.1-4.4.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.3.1-4.5">
-                <p id="section-5.2.3.1-4.5.1"><strong>organizationalUnitName (OID 2.5.4.11):</strong> CNPJ da Autoridade de Registro<a href="#section-5.2.3.1-4.5.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.3.1-4.6">
-                <p id="section-5.2.3.1-4.6.1"><strong>organizationalUnitName (OID 2.5.4.11):</strong> Tipo de identifica&#231;&#227;o utilizada (presencial, videoconfer&#234;ncia ou certificado digital)<a href="#section-5.2.3.1-4.6.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.3.1-4.7">
-                <p id="section-5.2.3.1-4.7.1"><strong>commonName (OID 2.5.4.3):</strong> Nome da Raz&#227;o Social<a href="#section-5.2.3.1-4.7.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-<p id="section-5.2.3.1-5"><strong>Certificate Extensions</strong><a href="#section-5.2.3.1-5" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-5.2.3.1-6.1">
-                <p id="section-5.2.3.1-6.1.1"><strong>keyUsage:</strong> critical,digitalSignature,nonRepudiation<a href="#section-5.2.3.1-6.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-<p id="section-5.2.3.1-7"><strong>Subject Alternative Name</strong><a href="#section-5.2.3.1-7" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-5.2.3.1-8.1">
-                <p id="section-5.2.3.1-8.1.1"><strong>otherName (OID 2.16.76.1.3.2 - ICP-Brasil):</strong> Nome do respons&#225;vel pelo certificado<a href="#section-5.2.3.1-8.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.3.1-8.2">
-                <p id="section-5.2.3.1-8.2.1"><strong>otherName (OID 2.16.76.1.3.3 - ICP-Brasil):</strong> Cadastro Nacional de Pessoa Jur&#237;dica (CNPJ) da pessoa jur&#237;dica titular do certificado;<a href="#section-5.2.3.1-8.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.3.1-8.3">
-                <p id="section-5.2.3.1-8.3.1"><strong>otherName (OID 2.16.76.1.3.4 - ICP-Brasil):</strong> Respons&#225;vel pelo certificado de pessoa juri&#769;dica titular do certificado (data de nascimento, CPF, PIS/PASEP/CI, RG);<a href="#section-5.2.3.1-8.3.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.3.1-8.4">
-                <p id="section-5.2.3.1-8.4.1"><strong>otherName (OID 2.16.76.1.3.7  - ICP-Brasil):</strong> N&#250;mero do Cadastro Especifico do INSS (CEI) da pessoa jur&#237;dica titular do certificado.<a href="#section-5.2.3.1-8.4.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</section>
-</div>
-<div id="autoridades-certificadoras-participantes">
-<section id="section-5.2.3.2">
-            <h5 id="name-autoridades-certificadoras-">
-<a href="#section-5.2.3.2" class="section-number selfRef">5.2.3.2. </a><a href="#name-autoridades-certificadoras-" class="section-name selfRef">Autoridades Certificadoras Participantes</a>
-            </h5>
-<p id="section-5.2.3.2-1">A lista abaixa representa a lista de autoridades certificadoras que realizaram o processo de onboard ao Open Banking Brasil e est&#227;o habilitadas para realizar a emiss&#227;o de certificados do Open Banking Brasil.<a href="#section-5.2.3.2-1" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-5.2.3.2-2.1">
-                <p id="section-5.2.3.2-2.1.1">N/A<a href="#section-5.2.3.2-2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</section>
-</div>
-</section>
-</div>
-<div id="certificado-para-front-end">
-<section id="section-5.2.4">
-          <h4 id="name-certificado-para-front-end">
-<a href="#section-5.2.4" class="section-number selfRef">5.2.4. </a><a href="#name-certificado-para-front-end" class="section-name selfRef">Certificado para Front-End</a>
-          </h4>
-<p id="section-5.2.4-1">Os certificados para Front-End s&#227;o utilziados para disponibilizar os servi&#231;os, em geral p&#225;ginas Web, com uso de TLS, na qual s&#227;o acessado por usu&#225;rio final. Dado a sua finalidade, e para garantir maior interoperabilidade. Os certificados devem ser do tipo EV (Extended Validation) e deve ser ser gerado atrav&#233;s de uma autoridade certificadora v&#225;lida,
-seguindo as regras definidas na RFC 5280 e RFC 2818, em conformidade com os princ&#237;pios e crit&#233;rios WebTrust.<a href="#section-5.2.4-1" class="pilcrow">¶</a></p>
-</section>
-</div>
-</section>
-</div>
-</section>
-</div>
-<div id="reconhecimento">
-<section id="section-6">
-      <h2 id="name-reconhecimento">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-reconhecimento" class="section-name selfRef">Reconhecimento</a>
-      </h2>
-<p id="section-6-1">Agradecemos a todos que estabeleceram as bases para o compartilhamento seguro e seguro de dados por meio da forma&#231;&#227;o do Grupo de Trabalho FAPI da OpenID Foundation, o GT-Seguran&#231;a do Open Banking Brasil e aos pioneiros que ficar&#227;o em seus ombros.<a href="#section-6-1" class="pilcrow">¶</a></p>
-<p id="section-6-2">As seguintes pessoas contribu&#237;ram para este documento:<a href="#section-6-2" class="pilcrow">¶</a></p>
-<ul>
-<li id="section-6-3.1">
-          <p id="section-6-3.1.1">Marcos Rodrigues (Ita&#250;)<a href="#section-6-3.1.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-6-3.2">
-          <p id="section-6-3.2.1">Jos&#233; Michael Dias (Grupo Pan)<a href="#section-6-3.2.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-6-3.3">
-          <p id="section-6-3.3.1">Ralph Bragg (Raidiam)<a href="#section-6-3.3.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
-</section>
-</div>
-<div id="informativo">
-<section id="section-7">
-      <h2 id="name-informativo">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-informativo" class="section-name selfRef">Informativo</a>
-      </h2>
-<p id="section-7-1">Copyright (c) 2021 Estrutura Inicial do Open Banking Brasil.<a href="#section-7-1" class="pilcrow">¶</a></p>
-<p id="section-7-2">A Estrutura Inicial do Open Banking Brasil (EIOBB) concede a qualquer Colaborador, desenvolvedor, implementador ou outra parte interessada uma licen&#231;a de direitos autorais mundial n&#227;o exclusiva, livre de royalties para reproduzir, preparar trabalhos derivados, distribuir, executar e exibir, estes Implementadores Rascunho ou Especifica&#231;&#227;o Final exclusivamente para fins de (i) desenvolver especifica&#231;&#245;es e (ii) implementar Rascunhos de Implementa&#231;&#245;es e Especifica&#231;&#245;es Finais com base em tais documentos, desde que a atribui&#231;&#227;o seja feita ao EIOBB como a fonte do material, mas que tal atribui&#231;&#227;o o fa&#231;a n&#227;o indica endosso do EIOBB.<a href="#section-7-2" class="pilcrow">¶</a></p>
-<p id="section-7-3">A tecnologia descrita nesta especifica&#231;&#227;o foi disponibilizada a partir de contribui&#231;&#245;es de v&#225;rias fontes, incluindo membros da OpenID Foundation, do GT-Seguran&#231;a do Open Banking Brasil e outros. Embora a Estrutura Inicial do Open Banking Brasil tenha tomado medidas para ajudar a garantir que a tecnologia esteja dispon&#237;vel para distribui&#231;&#227;o, ela n&#227;o toma posi&#231;&#227;o quanto &#224; validade ou escopo de qualquer propriedade intelectual ou outros direitos que possam ser reivindicados como pertencentes &#224; implementa&#231;&#227;o ou uso do tecnologia descrita nesta especifica&#231;&#227;o ou at&#233; que ponto qualquer licen&#231;a sob tais direitos pode ou n&#227;o estar dispon&#237;vel; nem representa que fez qualquer esfor&#231;o independente para identificar tais direitos. A Estrutura Inicial do Open Banking Brasil e os contribuidores desta especifica&#231;&#227;o n&#227;o oferecem (e por meio deste expressamente se isentam de quaisquer) garantias (expressas, impl&#237;citas ou de outra forma), incluindo garantias impl&#237;citas de comercializa&#231;&#227;o, n&#227;o viola&#231;&#227;o, adequa&#231;&#227;o a uma finalidade espec&#237;fica ou t&#237;tulo, relacionados a esta especifica&#231;&#227;o, e todo o risco quanto &#224; implementa&#231;&#227;o desta especifica&#231;&#227;o &#233; assumido pelo implementador. A pol&#237;tica de Direitos de Propriedade Intelectual do Open Banking Brasil exige que os contribuidores ofere&#231;am uma promessa de patente de n&#227;o fazer valer certas reivindica&#231;&#245;es de patentes contra outros contribuidores e implementadores. A Estrutura Inicial do Open Banking Brasil convida qualquer parte interessada a trazer &#224; sua aten&#231;&#227;o quaisquer direitos autorais, patentes, pedidos de patentes ou outros direitos de propriedade que possam abranger a tecnologia que possa ser necess&#225;ria para praticar esta especifica&#231;&#227;o.<a href="#section-7-3" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="apendice">
-<section id="section-8">
-      <h2 id="name-apendice">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-apendice" class="section-name selfRef">Apendice</a>
-      </h2>
-<div id="modelo-de-configuracao-de-certificado-cliente-openssl">
-<section id="section-8.1">
-        <h3 id="name-modelo-de-configuracao-de-c">
-<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-modelo-de-configuracao-de-c" class="section-name selfRef">Modelo de Configuracao de Certificado Cliente - OpenSSL</a>
-        </h3>
-<div class="artwork art-text alignLeft" id="section-8.1-1">
-<pre>[req]
+        <nav class="toc">
+          <ul class="toc ulEmpty">
+            <li class="toc ulEmpty" id="section-toc.1-1.1">
+              <p id="section-toc.1-1.1.1">
+                <a href="#section-1" class="xref">1</a>.  <a
+                  href="#name-escopo"
+                  class="xref"
+                  >Escopo</a
+                ><a href="#section-toc.1-1.1.1" class="pilcrow">¶</a>
+              </p>
+            </li>
+            <li class="toc ulEmpty" id="section-toc.1-1.2">
+              <p id="section-toc.1-1.2.1">
+                <a href="#section-2" class="xref">2</a>.  <a
+                  href="#name-refer234ncias-normativas"
+                  class="xref"
+                  >Refer&#234;ncias Normativas</a
+                ><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a>
+              </p>
+            </li>
+            <li class="toc ulEmpty" id="section-toc.1-1.3">
+              <p id="section-toc.1-1.3.1">
+                <a href="#section-3" class="xref">3</a>.  <a
+                  href="#name-termos-e-definicoes"
+                  class="xref"
+                  >Termos e Definicoes</a
+                ><a href="#section-toc.1-1.3.1" class="pilcrow">¶</a>
+              </p>
+            </li>
+            <li class="toc ulEmpty" id="section-toc.1-1.4">
+              <p id="section-toc.1-1.4.1">
+                <a href="#section-4" class="xref">4</a>.  <a
+                  href="#name-glossario"
+                  class="xref"
+                  >Glossario</a
+                ><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a>
+              </p>
+            </li>
+            <li class="toc ulEmpty" id="section-toc.1-1.5">
+              <p id="section-toc.1-1.5.1">
+                <a href="#section-5" class="xref">5</a>.  <a
+                  href="#name-padrao-de-certificados-open"
+                  class="xref"
+                  >Padrao de Certificados Open Banking Brasil</a
+                ><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a>
+              </p>
+              <ul class="toc ulEmpty">
+                <li class="toc ulEmpty" id="section-toc.1-1.5.2.1">
+                  <p id="section-toc.1-1.5.2.1.1">
+                    <a href="#section-5.1" class="xref">5.1</a>.  <a
+                      href="#name-introducao"
+                      class="xref"
+                      >Introducao</a
+                    ><a href="#section-toc.1-1.5.2.1.1" class="pilcrow">¶</a>
+                  </p>
+                </li>
+                <li class="toc ulEmpty" id="section-toc.1-1.5.2.2">
+                  <p id="section-toc.1-1.5.2.2.1">
+                    <a href="#section-5.2" class="xref">5.2</a>.  <a
+                      href="#name-certificados-icp-brasil"
+                      class="xref"
+                      >Certificados ICP-Brasil</a
+                    ><a href="#section-toc.1-1.5.2.2.1" class="pilcrow">¶</a>
+                  </p>
+                  <ul class="toc ulEmpty">
+                    <li class="toc ulEmpty" id="section-toc.1-1.5.2.2.2.1">
+                      <p id="section-toc.1-1.5.2.2.2.1.1">
+                        <a href="#section-5.2.1" class="xref">5.2.1</a>.  <a
+                          href="#name-certificado-servidor"
+                          class="xref"
+                          >Certificado Servidor</a
+                        ><a href="#section-toc.1-1.5.2.2.2.1.1" class="pilcrow"
+                          >¶</a
+                        >
+                      </p>
+                    </li>
+                    <li class="toc ulEmpty" id="section-toc.1-1.5.2.2.2.2">
+                      <p id="section-toc.1-1.5.2.2.2.2.1">
+                        <a href="#section-5.2.2" class="xref">5.2.2</a>.  <a
+                          href="#name-certificado-cliente"
+                          class="xref"
+                          >Certificado Cliente</a
+                        ><a href="#section-toc.1-1.5.2.2.2.2.1" class="pilcrow"
+                          >¶</a
+                        >
+                      </p>
+                    </li>
+                    <li class="toc ulEmpty" id="section-toc.1-1.5.2.2.2.3">
+                      <p id="section-toc.1-1.5.2.2.2.3.1">
+                        <a href="#section-5.2.3" class="xref">5.2.3</a>.  <a
+                          href="#name-certificado-de-assinatura"
+                          class="xref"
+                          >Certificado de Assinatura</a
+                        ><a href="#section-toc.1-1.5.2.2.2.3.1" class="pilcrow"
+                          >¶</a
+                        >
+                      </p>
+                    </li>
+                    <li class="toc ulEmpty" id="section-toc.1-1.5.2.2.2.4">
+                      <p id="section-toc.1-1.5.2.2.2.4.1">
+                        <a href="#section-5.2.4" class="xref">5.2.4</a>.  <a
+                          href="#name-certificado-para-front-end"
+                          class="xref"
+                          >Certificado para Front-End</a
+                        ><a href="#section-toc.1-1.5.2.2.2.4.1" class="pilcrow"
+                          >¶</a
+                        >
+                      </p>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+            <li class="toc ulEmpty" id="section-toc.1-1.6">
+              <p id="section-toc.1-1.6.1">
+                <a href="#section-6" class="xref">6</a>.  <a
+                  href="#name-reconhecimento"
+                  class="xref"
+                  >Reconhecimento</a
+                ><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a>
+              </p>
+            </li>
+            <li class="toc ulEmpty" id="section-toc.1-1.7">
+              <p id="section-toc.1-1.7.1">
+                <a href="#section-7" class="xref">7</a>.  <a
+                  href="#name-informativo"
+                  class="xref"
+                  >Informativo</a
+                ><a href="#section-toc.1-1.7.1" class="pilcrow">¶</a>
+              </p>
+            </li>
+            <li class="toc ulEmpty" id="section-toc.1-1.8">
+              <p id="section-toc.1-1.8.1">
+                <a href="#section-8" class="xref">8</a>.  <a
+                  href="#name-apendice"
+                  class="xref"
+                  >Apendice</a
+                ><a href="#section-toc.1-1.8.1" class="pilcrow">¶</a>
+              </p>
+              <ul class="toc ulEmpty">
+                <li class="toc ulEmpty" id="section-toc.1-1.8.2.1">
+                  <p id="section-toc.1-1.8.2.1.1">
+                    <a href="#section-8.1" class="xref">8.1</a>.  <a
+                      href="#name-modelo-de-configuracao-de-c"
+                      class="xref"
+                      >Modelo de Configuracao de Certificado Cliente -
+                      OpenSSL</a
+                    ><a href="#section-toc.1-1.8.2.1.1" class="pilcrow">¶</a>
+                  </p>
+                </li>
+                <li class="toc ulEmpty" id="section-toc.1-1.8.2.2">
+                  <p id="section-toc.1-1.8.2.2.1">
+                    <a href="#section-8.2" class="xref">8.2</a>.  <a
+                      href="#name-modelo-de-configuracao-de-ce"
+                      class="xref"
+                      >Modelo de Configuracao de Certificado de Assinatura -
+                      OpenSSL</a
+                    ><a href="#section-toc.1-1.8.2.2.1" class="pilcrow">¶</a>
+                  </p>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </nav>
+      </section>
+    </div>
+    <div id="escopo">
+      <section id="section-1">
+        <h2 id="name-escopo">
+          <a href="#section-1" class="section-number selfRef">1. </a
+          ><a href="#name-escopo" class="section-name selfRef">Escopo</a>
+        </h2>
+        <p id="section-1-1">
+          Este documento especifica os tipos de certificados necess&#225;rios
+          para:<a href="#section-1-1" class="pilcrow">¶</a>
+        </p>
+        <ul>
+          <li id="section-1-2.1">
+            <p id="section-1-2.1.1">
+              Autenticar mutuamente (MTLS - Mutual - TLS) as
+              aplica&#231;&#245;es dos participantes;<a
+                href="#section-1-2.1.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-1-2.2">
+            <p id="section-1-2.2.1">
+              Assinatura de Mensagens (JWS - JSON Web Signature) de
+              aplica&#231;&#245;es para garantir a autenticidade e n&#227;o
+              rep&#250;dio de mensagens entre os participantes;<a
+                href="#section-1-2.2.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-1-2.3">
+            <p id="section-1-2.3.1">
+              Apresentar um canal seguro e confi&#225;vel para clientes do Open
+              Banking Brasil;<a href="#section-1-2.3.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-1-2.4">
+            <p id="section-1-2.4.1">
+              Autenticar participantes junto do Diret&#243;rio de participantes
+              do Open Banking Brasil.<a href="#section-1-2.4.1" class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+        </ul>
+      </section>
+    </div>
+    <div id="References">
+      <section id="section-2">
+        <h2 id="name-refer234ncias-normativas">
+          <a href="#section-2" class="section-number selfRef">2. </a
+          ><a href="#name-refer234ncias-normativas" class="section-name selfRef"
+            >Refer&#234;ncias Normativas</a
+          >
+        </h2>
+        <p id="section-2-1">
+          Os seguintes documentos referenciados s&#227;o indispens&#225;veis
+          para a aplica&#231;&#227;o deste documento. Para refer&#234;ncias
+          datadas, apenas a edi&#231;&#227;o citada se aplica. Para
+          refer&#234;ncias n&#227;o datadas, a &#250;ltima edi&#231;&#227;o do
+          documento referenciado (incluindo quaisquer emendas) se aplica.<a
+            href="#section-2-1"
+            class="pilcrow"
+            >¶</a
+          >
+        </p>
+        <ul>
+          <li id="section-2-2.1">
+            <p id="section-2-2.1.1">
+              [ISODIR2] - ISO/IEC Directives Part 2 [ISODIR2]:
+              <a
+                href="https://www.iso.org/sites/directives/current/part2/index.xhtml"
+                >https://www.iso.org/sites/directives/current/part2/index.xhtml</a
+              ><a href="#section-2-2.1.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.2">
+            <p id="section-2-2.2.1">
+              [RFC5280] - Internet X.509 Public Key Infrastructure Certificate
+              and Certificate Revocation List (CRL) Profile:
+              <a href="https://datatracker.ietf.org/doc/html/rfc5280"
+                >https://datatracker.ietf.org/doc/html/rfc5280</a
+              ><a href="#section-2-2.2.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.3">
+            <p id="section-2-2.3.1">
+              [RFC7519] - JSON Web Token (JWT) [RFC7519]:<a
+                href="https://tools.ietf.org/html/rfc7519"
+                >https://tools.ietf.org/html/rfc7519</a
+              ><a href="#section-2-2.3.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.4">
+            <p id="section-2-2.4.1">
+              [RFC7515] - JSON Web Signature (JWS) [RFC7515] :<a
+                href="https://datatracker.ietf.org/doc/html/rfc7515"
+                >https://datatracker.ietf.org/doc/html/rfc7515</a
+              ><a href="#section-2-2.4.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.5">
+            <p id="section-2-2.5.1">
+              [RFC7591] - OAuth 2.0 Dynamic Client Registration Protocol
+              [RFC7591]:<a href="https://tools.ietf.org/html/rfc7591"
+                >https://tools.ietf.org/html/rfc7591</a
+              ><a href="#section-2-2.5.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.6">
+            <p id="section-2-2.6.1">
+              [RFC7592] - OAuth 2.0 Dynamic Client Registration Management
+              Protocol [RFC7592]:<a href="https://tools.ietf.org/html/rfc7592"
+                >https://tools.ietf.org/html/rfc7592</a
+              ><a href="#section-2-2.6.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.7">
+            <p id="section-2-2.7.1">
+              [BCP195] - Recommendations for Secure Use of Transport Layer
+              Security (TLS) and Datagram Transport Layer Security (DTLS)
+              [BCP195]:
+              <a href="https://tools.ietf.org/html/bcp195"
+                >https://tools.ietf.org/html/bcp195</a
+              ><a href="#section-2-2.7.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.8">
+            <p id="section-2-2.8.1">
+              [RFC8705] - OAuth 2.0 Mutual TLS Client Authentication and
+              Certificate Bound Access Tokens [RFC8705]:
+              <a href="https://tools.ietf.org/html/rfc8705"
+                >https://tools.ietf.org/html/rfc8705</a
+              ><a href="#section-2-2.8.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.9">
+            <p id="section-2-2.9.1">
+              [OBB-FAPI] - Open Banking Brasil Financial-grade API Security
+              Profile 1.0 [OBB-FAPI]:
+              <a
+                href="https://github.com/OpenBanking-Brasil/specs-seguranca/open-banking-brasil-financial-api-1_ID1.html"
+                >https://github.com/OpenBanking-Brasil/specs-seguranca/open-banking-brasil-financial-api-1_ID1.html</a
+              ><a href="#section-2-2.9.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.10">
+            <p id="section-2-2.10.1">
+              [DOC-ICP-01] - DECLARA&#199;&#195;O DE PR&#193;TICAS DE
+              CERTIFICA&#199;&#195;O DA AUTORIDADE CERTIFICADORA RAIZ DA
+              ICP-BRASIL:
+              <a
+                href="https://www.gov.br/iti/pt-br/centrais-de-conteudo/doc-icp-01-v-5-2-dpc-da-ac-raiz-da-icp-brasil-pdf"
+                >https://www.gov.br/iti/pt-br/centrais-de-conteudo/doc-icp-01-v-5-2-dpc-da-ac-raiz-da-icp-brasil-pdf</a
+              ><a href="#section-2-2.10.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.11">
+            <p id="section-2-2.11.1">
+              [RFC6749] - The OAuth 2.0 Authorization Framework [RFC6749]:
+              <a href="https://tools.ietf.org/html/rfc6749"
+                >https://tools.ietf.org/html/rfc6749</a
+              ><a href="#section-2-2.11.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.12">
+            <p id="section-2-2.12.1">
+              [BCB-IN99] - Manual de Seguran&#231;a do Open Banking:
+              <a
+                href="https://www.in.gov.br/en/web/dou/-/instrucao-normativa-bcb-n-99-de-14-de-abril-de-2021-314641007"
+                >https://www.in.gov.br/en/web/dou/-/instrucao-normativa-bcb-n-99-de-14-de-abril-de-2021-314641007</a
+              ><a href="#section-2-2.12.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+          <li id="section-2-2.13">
+            <p id="section-2-2.13.1">
+              [RFC2818] - HTTP Over TLS:
+              <a href="https://datatracker.ietf.org/doc/html/rfc2818"
+                >https://datatracker.ietf.org/doc/html/rfc2818</a
+              ><a href="#section-2-2.13.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+        </ul>
+      </section>
+    </div>
+    <div id="termos-e-definicoes">
+      <section id="section-3">
+        <h2 id="name-termos-e-definicoes">
+          <a href="#section-3" class="section-number selfRef">3. </a
+          ><a href="#name-termos-e-definicoes" class="section-name selfRef"
+            >Termos e Definicoes</a
+          >
+        </h2>
+        <p id="section-3-1">
+          Para o prop&#243;sito deste documento os termos definidos na [RFC5280,
+          [BCP195], [RFC8705], e ISO29100 s&#227;o aplic&#225;veis.<a
+            href="#section-3-1"
+            class="pilcrow"
+            >¶</a
+          >
+        </p>
+      </section>
+    </div>
+    <div id="glossario">
+      <section id="section-4">
+        <h2 id="name-glossario">
+          <a href="#section-4" class="section-number selfRef">4. </a
+          ><a href="#name-glossario" class="section-name selfRef">Glossario</a>
+        </h2>
+        <ul>
+          <li id="section-4-1.1">
+            <p id="section-4-1.1.1">
+              <strong>SSA</strong> - Software Statement Assertion<a
+                href="#section-4-1.1.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-4-1.2">
+            <p id="section-4-1.2.1">
+              <strong>SS</strong> - Software Statement<a
+                href="#section-4-1.2.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-4-1.3">
+            <p id="section-4-1.3.1">
+              <strong>DCR</strong> - Dynamic Client Registration<a
+                href="#section-4-1.3.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-4-1.4">
+            <p id="section-4-1.4.1">
+              <strong>API</strong> - Application Programming Interface<a
+                href="#section-4-1.4.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-4-1.5">
+            <p id="section-4-1.5.1">
+              <strong>HTTP</strong> - Hyper Text Transfer Protocol<a
+                href="#section-4-1.5.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-4-1.6">
+            <p id="section-4-1.6.1">
+              <strong>TLS</strong> - Transport Layer Security<a
+                href="#section-4-1.6.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-4-1.7">
+            <p id="section-4-1.7.1">
+              <strong>mTLS</strong> - Mutual Transport Layer Security<a
+                href="#section-4-1.7.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-4-1.8">
+            <p id="section-4-1.8.1">
+              <strong>ICP</strong> - Infraestrutura de Chave P&#250;blicas
+              Brasileira<a href="#section-4-1.8.1" class="pilcrow">¶</a>
+            </p>
+          </li>
+        </ul>
+      </section>
+    </div>
+    <div id="padrao-de-certificados-open-banking-brasil">
+      <section id="section-5">
+        <h2 id="name-padrao-de-certificados-open">
+          <a href="#section-5" class="section-number selfRef">5. </a
+          ><a
+            href="#name-padrao-de-certificados-open"
+            class="section-name selfRef"
+            >Padrao de Certificados Open Banking Brasil</a
+          >
+        </h2>
+        <div id="introducao">
+          <section id="section-5.1">
+            <h3 id="name-introducao">
+              <a href="#section-5.1" class="section-number selfRef">5.1. </a
+              ><a href="#name-introducao" class="section-name selfRef"
+                >Introducao</a
+              >
+            </h3>
+            <p id="section-5.1-1">
+              O sistema de Open Banking Brasil faz uso de cadeias de
+              certificados e protocolo TLS para garantir a confidencialidade,
+              autentica&#231;&#227;o e integridade do canal de
+              comunica&#231;&#227;o utilizado pelas APIs das
+              institui&#231;&#245;es participantes do Ecossistema bem como dos
+              clientes de cada um dos participantes.<a
+                href="#section-5.1-1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+            <p id="section-5.1-2">
+              Os certificados utilizados para o Open Banking Brasil tamb&#233;m
+              s&#227;o necess&#225;rios para autenticar as aplica&#231;&#245;es
+              atrav&#233;s do oAuth 2.0 mTLS ou private<em>key</em>jwt,
+              al&#233;m de tamb&#233;m servirem para realizar a assinatura de
+              payload pelo uso de JWS. Outra atribui&#231;&#227;o importante dos
+              certificados &#233; realizar a autentica&#231;&#227;o e apresentar
+              um canal seguro para o usu&#225;rio final no ato de
+              autentica&#231;&#227;o e uso dos servi&#231;os prestados pela
+              entidade participante.<a href="#section-5.1-2" class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </section>
+        </div>
+        <div id="certificados-icp-brasil">
+          <section id="section-5.2">
+            <h3 id="name-certificados-icp-brasil">
+              <a href="#section-5.2" class="section-number selfRef">5.2. </a
+              ><a
+                href="#name-certificados-icp-brasil"
+                class="section-name selfRef"
+                >Certificados ICP-Brasil</a
+              >
+            </h3>
+            <p id="section-5.2-1">
+              Os certificados emitidos junto a Autoridades Certificadoras
+              autorizadas pelo ICP-Brasil s&#227;o utilizados apenas na
+              comunica&#231;&#227;o entre as entidades participantes do
+              ecossistema do Open Banking Brasil.<a
+                href="#section-5.2-1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+            <p id="section-5.2-2">
+              Os processos de emiss&#227;o e revoga&#231;&#227;o dos
+              certificados s&#227;o de responsabilidade das pr&#243;prias
+              Autoridades Certificadores, sendo regulamentados por
+              Declara&#231;&#245;es de Pr&#225;tica de Certifica&#231;&#227;o, e
+              supervisionadas pelo Comit&#234; Gestor da Infraestrutura de
+              Chaves P&#250;blicas Brasileira.<a
+                href="#section-5.2-2"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+            <p id="section-5.2-3">
+              As pr&#225;ticas, processos, disponibiliza&#231;&#227;o e valores
+              praticados pelas Autoridades Certificadoras n&#227;o s&#227;o de
+              responsabilidade do Estrutura Inicial do Open Banking Brasil.<a
+                href="#section-5.2-3"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+            <p id="section-5.2-4">
+              <strong>Algoritmos</strong
+              ><a href="#section-5.2-4" class="pilcrow">¶</a>
+            </p>
+            <p id="section-5.2-5">
+              Todos os certificados emitidos junto ao ICP-Brasil devem possuir
+              as seguintes caracter&#237;sticas:<a
+                href="#section-5.2-5"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+            <ul>
+              <li id="section-5.2-6.1">
+                <p id="section-5.2-6.1.1">
+                  Tipo A do ICP-Brasil;<a
+                    href="#section-5.2-6.1.1"
+                    class="pilcrow"
+                    >¶</a
+                  >
+                </p>
+              </li>
+              <li id="section-5.2-6.2">
+                <p id="section-5.2-6.2.1">
+                  Algoritmo de Chaves: RSA 2048 bits;<a
+                    href="#section-5.2-6.2.1"
+                    class="pilcrow"
+                    >¶</a
+                  >
+                </p>
+              </li>
+              <li id="section-5.2-6.3">
+                <p id="section-5.2-6.3.1">
+                  Message Digest: SHA 256 bits.<a
+                    href="#section-5.2-6.3.1"
+                    class="pilcrow"
+                    >¶</a
+                  >
+                </p>
+              </li>
+            </ul>
+            <div id="certificado-servidor">
+              <section id="section-5.2.1">
+                <h4 id="name-certificado-servidor">
+                  <a href="#section-5.2.1" class="section-number selfRef"
+                    >5.2.1. </a
+                  ><a
+                    href="#name-certificado-servidor"
+                    class="section-name selfRef"
+                    >Certificado Servidor</a
+                  >
+                </h4>
+                <p id="section-5.2.1-1">
+                  O Certificado Servidor deve ser emitido para proteger e
+                  autenticar o canal TLS utilizado pelas APIs que ser&#227;o
+                  consumidas pelas aplica&#231;&#245;es cliente de entidades
+                  participantes do Open Banking.<a
+                    href="#section-5.2.1-1"
+                    class="pilcrow"
+                    >¶</a
+                  >
+                </p>
+                <p id="section-5.2.1-2">
+                  O padr&#227;o de certificado utilizado deve seguir as
+                  pr&#225;ticas de emiss&#227;o de certificados existentes de
+                  "CERTIFICADO PARA SERVIDOR WEB - ICP-Brasil".<a
+                    href="#section-5.2.1-2"
+                    class="pilcrow"
+                    >¶</a
+                  >
+                </p>
+              </section>
+            </div>
+            <div id="certificado-cliente">
+              <section id="section-5.2.2">
+                <h4 id="name-certificado-cliente">
+                  <a href="#section-5.2.2" class="section-number selfRef"
+                    >5.2.2. </a
+                  ><a
+                    href="#name-certificado-cliente"
+                    class="section-name selfRef"
+                    >Certificado Cliente</a
+                  >
+                </h4>
+                <p id="section-5.2.2-1">
+                  Os certificados de Open Banking, denominados Certificado de
+                  Aplica&#231;&#227;o Cliente (Transporte) s&#227;o utilizados
+                  para autenticar o canal MTLS. Os Certificados Cliente
+                  tamb&#233;m s&#227;o utilizados para realizar a
+                  autentica&#231;&#227;o da aplica&#231;&#227;o cliente
+                  atrav&#233;s de oAuth2.0 mTLS ou private<em>key</em>jwt, de
+                  acordo com cadastro da aplica&#231;&#227;o realizado o
+                  processo de Dynamic Client Registration junto a entidade
+                  transmissora.<a href="#section-5.2.2-1" class="pilcrow">¶</a>
+                </p>
+                <p id="section-5.2.2-2">
+                  Para emiss&#227;o de certificado de cliente &#233;
+                  necess&#225;rio que a institui&#231;&#227;o participante do
+                  Open Banking Brasil tenha realizado o cadastro de
+                  aplica&#231;&#227;o ao diret&#243;rio, atrav&#233;s do
+                  processo de emiss&#227;o de Software Statement Assertion, e
+                  com isso j&#225; tenha obtido o valor de Software Statement
+                  ID.<a href="#section-5.2.2-2" class="pilcrow">¶</a>
+                </p>
+                <div id="atributos-openbanking-brasil">
+                  <section id="section-5.2.2.1">
+                    <h5 id="name-atributos-openbanking-brasi">
+                      <a href="#section-5.2.2.1" class="section-number selfRef"
+                        >5.2.2.1. </a
+                      ><a
+                        href="#name-atributos-openbanking-brasi"
+                        class="section-name selfRef"
+                        >Atributos OpenBanking Brasil</a
+                      >
+                    </h5>
+                    <ul>
+                      <li id="section-5.2.2.1-1.1">
+                        <p id="section-5.2.2.1-1.1.1">
+                          <strong>serialNumber:</strong> Cadastro Nacional de
+                          Pessoal Juridica (CNPJ) da pessoa jur&#237;dica
+                          titular do certificado e associado ao atributo UID e
+                          Software Statement ID, durante valida&#231;&#227;o
+                          junto ao Servi&#231;o de Diret&#243;rio do OpenBanking
+                          Brasil;<a
+                            href="#section-5.2.2.1-1.1.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-1.2">
+                        <p id="section-5.2.2.1-1.2.1">
+                          <strong>organizationalUnitName:</strong> C&#243;digo
+                          de Participante associado ao CNPJ listado no
+                          Servi&#231;o de Diret&#243;rio do OpenBanking
+                          Brasil;<a
+                            href="#section-5.2.2.1-1.2.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-1.3">
+                        <p id="section-5.2.2.1-1.3.1">
+                          <strong>UID:</strong> Software Statement ID cadastrado
+                          no Servi&#231;o de Diret&#243;rio do OpenBanking
+                          Brasil e pertencente ao CNPJ e C&#243;digo de
+                          Participante.<a
+                            href="#section-5.2.2.1-1.3.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                    </ul>
+                    <p id="section-5.2.2.1-2">
+                      O Certificado Cliente deve ser emitido atrav&#233;s de
+                      cadeia V10, e deve obrigatoriamente conter os seguintes
+                      atributos:<a href="#section-5.2.2.1-2" class="pilcrow"
+                        >¶</a
+                      >
+                    </p>
+                    <p id="section-5.2.2.1-3">
+                      <strong>Distinguished Name</strong
+                      ><a href="#section-5.2.2.1-3" class="pilcrow">¶</a>
+                    </p>
+                    <ul>
+                      <li id="section-5.2.2.1-4.1">
+                        <p id="section-5.2.2.1-4.1.1">
+                          <strong>businessCategory (OID 2.5.4.15):</strong> Tipo
+                          de categoria comercial, devendo conter: "Private
+                          Organization" ou "Government Entity" ou "Business
+                          Entity" ou "Non-Commercial Entity"<a
+                            href="#section-5.2.2.1-4.1.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-4.2">
+                        <p id="section-5.2.2.1-4.2.1">
+                          <strong
+                            >jurisdictionCountryName (OID:
+                            1.3.6.1.4.1.311.60.2.1.3):</strong
+                          >
+                          BR<a href="#section-5.2.2.1-4.2.1" class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-4.3">
+                        <p id="section-5.2.2.1-4.3.1">
+                          <strong>serialNumber (OID 2.5.4.5):</strong> CNPJ<a
+                            href="#section-5.2.2.1-4.3.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-4.4">
+                        <p id="section-5.2.2.1-4.4.1">
+                          <strong>countryName (OID 2.5.4.6):</strong> BR<a
+                            href="#section-5.2.2.1-4.4.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-4.5">
+                        <p id="section-5.2.2.1-4.5.1">
+                          <strong>organizationName (OID 2.5.4.10):</strong>
+                          Raz&#227;o Social<a
+                            href="#section-5.2.2.1-4.5.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-4.6">
+                        <p id="section-5.2.2.1-4.6.1">
+                          <strong>stateOrProvinceName (OID 2.5.4.8):</strong>
+                          Unidade da federa&#231;&#227;o do endere&#231;o
+                          f&#237;sico do titular do certificado<a
+                            href="#section-5.2.2.1-4.6.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-4.7">
+                        <p id="section-5.2.2.1-4.7.1">
+                          <strong>localityName (OID 2.5.4.7):</strong> Cidade do
+                          endere&#231;o f&#237;sico do titular<a
+                            href="#section-5.2.2.1-4.7.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-4.8">
+                        <p id="section-5.2.2.1-4.8.1">
+                          <strong
+                            >organizationalUnitName (OID 2.5.4.11):</strong
+                          >
+                          C&#243;digo de Participante associado ao CNPJ listado
+                          no Servi&#231;o de Diret&#243;rio do OpenBanking
+                          Brasil<a href="#section-5.2.2.1-4.8.1" class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-4.9">
+                        <p id="section-5.2.2.1-4.9.1">
+                          <strong>UID (OID 0.9.2342.19200300.100.1.1):</strong>
+                          Software Statement ID gerado pelo Diret&#243;rio do
+                          Open Banking Brasil<a
+                            href="#section-5.2.2.1-4.9.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-4.10">
+                        <p id="section-5.2.2.1-4.10.1">
+                          <strong>commonName (OID 2.5.4.3):</strong> FQDN ou
+                          Wildcard<a
+                            href="#section-5.2.2.1-4.10.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                    </ul>
+                    <p id="section-5.2.2.1-5">
+                      <strong>Certificate Extensions</strong
+                      ><a href="#section-5.2.2.1-5" class="pilcrow">¶</a>
+                    </p>
+                    <ul>
+                      <li id="section-5.2.2.1-6.1">
+                        <p id="section-5.2.2.1-6.1.1">
+                          <strong>keyUsage:</strong>
+                          critical,digitalSignature,keyEncipherment<a
+                            href="#section-5.2.2.1-6.1.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.2.1-6.2">
+                        <p id="section-5.2.2.1-6.2.1">
+                          <strong>extendedKeyUsage:</strong> clientAuth<a
+                            href="#section-5.2.2.1-6.2.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                    </ul>
+                    <p id="section-5.2.2.1-7">
+                      <strong>Subject Alternative Name</strong
+                      ><a href="#section-5.2.2.1-7" class="pilcrow">¶</a>
+                    </p>
+                    <ul>
+                      <li id="section-5.2.2.1-8.1">
+                        <p id="section-5.2.2.1-8.1.1">
+                          <strong>dNSName:</strong> FQDN ou Wildcard<a
+                            href="#section-5.2.2.1-8.1.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                    </ul>
+                  </section>
+                </div>
+              </section>
+            </div>
+            <div id="certificado-de-assinatura">
+              <section id="section-5.2.3">
+                <h4 id="name-certificado-de-assinatura">
+                  <a href="#section-5.2.3" class="section-number selfRef"
+                    >5.2.3. </a
+                  ><a
+                    href="#name-certificado-de-assinatura"
+                    class="section-name selfRef"
+                    >Certificado de Assinatura</a
+                  >
+                </h4>
+                <p id="section-5.2.3-1">
+                  Os certificados de Open Banking, denominados Certificado de
+                  Assinatura (Assinatura) s&#227;o utilizados para realizar
+                  assinatura do payload atrav&#233;s do uso de JWS (JSON Web
+                  Signature).<a href="#section-5.2.3-1" class="pilcrow">¶</a>
+                </p>
+                <div
+                  id="atributos-open-banking-brasil-presentes-no-certificado"
+                >
+                  <section id="section-5.2.3.1">
+                    <h5 id="name-atributos-open-banking-bras">
+                      <a href="#section-5.2.3.1" class="section-number selfRef"
+                        >5.2.3.1. </a
+                      ><a
+                        href="#name-atributos-open-banking-bras"
+                        class="section-name selfRef"
+                        >Atributos Open Banking Brasil presentes no
+                        Certificado</a
+                      >
+                    </h5>
+                    <ul>
+                      <li id="section-5.2.3.1-1.1">
+                        <p id="section-5.2.3.1-1.1.1">
+                          <strong>UID:</strong> C&#243;digo de Participante
+                          associado ao CNPJ listado no Servi&#231;o de
+                          Diret&#243;rio do OpenBanking Brasil;<a
+                            href="#section-5.2.3.1-1.1.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.3.1-1.2">
+                        <p id="section-5.2.3.1-1.2.1">
+                          <strong>commonName:</strong> Raz&#227;o Social
+                          cadastrado no Servi&#231;o de Diret&#243;rio do
+                          OpenBanking Brasil e pertencente ao CNPJ e C&#243;digo
+                          de Participante.<a
+                            href="#section-5.2.3.1-1.2.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                    </ul>
+                    <p id="section-5.2.3.1-2">
+                      O Certificado de Assinatura deve ser emitido atrav&#233;s
+                      de cadeia V5, e deve obrigatoriamente conter os seguintes
+                      atributos:<a href="#section-5.2.3.1-2" class="pilcrow"
+                        >¶</a
+                      >
+                    </p>
+                    <p id="section-5.2.3.1-3">
+                      <strong>Distinguished Name</strong
+                      ><a href="#section-5.2.3.1-3" class="pilcrow">¶</a>
+                    </p>
+                    <ul>
+                      <li id="section-5.2.3.1-4.1">
+                        <p id="section-5.2.3.1-4.1.1">
+                          <strong>UID (OID 0.9.2342.19200300.100.1.1):</strong>
+                          C&#243;digo de Participante associado ao CNPJ listado
+                          no Servi&#231;o de Diret&#243;rio do OpenBanking
+                          Brasil<a href="#section-5.2.3.1-4.1.1" class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.3.1-4.2">
+                        <p id="section-5.2.3.1-4.2.1">
+                          <strong>countryName (OID 2.5.4.6):</strong> BR<a
+                            href="#section-5.2.3.1-4.2.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.3.1-4.3">
+                        <p id="section-5.2.3.1-4.3.1">
+                          <strong>organizationName (OID 2.5.4.10):</strong>
+                          ICP-Brasil<a
+                            href="#section-5.2.3.1-4.3.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.3.1-4.4">
+                        <p id="section-5.2.3.1-4.4.1">
+                          <strong
+                            >organizationalUnitName (OID 2.5.4.11):</strong
+                          >
+                          Nome da Autoridade Certificadora<a
+                            href="#section-5.2.3.1-4.4.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.3.1-4.5">
+                        <p id="section-5.2.3.1-4.5.1">
+                          <strong
+                            >organizationalUnitName (OID 2.5.4.11):</strong
+                          >
+                          CNPJ da Autoridade de Registro<a
+                            href="#section-5.2.3.1-4.5.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.3.1-4.6">
+                        <p id="section-5.2.3.1-4.6.1">
+                          <strong
+                            >organizationalUnitName (OID 2.5.4.11):</strong
+                          >
+                          Tipo de identifica&#231;&#227;o utilizada (presencial,
+                          videoconfer&#234;ncia ou certificado digital)<a
+                            href="#section-5.2.3.1-4.6.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.3.1-4.7">
+                        <p id="section-5.2.3.1-4.7.1">
+                          <strong>commonName (OID 2.5.4.3):</strong> Nome da
+                          Raz&#227;o Social<a
+                            href="#section-5.2.3.1-4.7.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                    </ul>
+                    <p id="section-5.2.3.1-5">
+                      <strong>Certificate Extensions</strong
+                      ><a href="#section-5.2.3.1-5" class="pilcrow">¶</a>
+                    </p>
+                    <ul>
+                      <li id="section-5.2.3.1-6.1">
+                        <p id="section-5.2.3.1-6.1.1">
+                          <strong>keyUsage:</strong>
+                          critical,digitalSignature,nonRepudiation<a
+                            href="#section-5.2.3.1-6.1.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                    </ul>
+                    <p id="section-5.2.3.1-7">
+                      <strong>Subject Alternative Name</strong
+                      ><a href="#section-5.2.3.1-7" class="pilcrow">¶</a>
+                    </p>
+                    <ul>
+                      <li id="section-5.2.3.1-8.1">
+                        <p id="section-5.2.3.1-8.1.1">
+                          <strong
+                            >otherName (OID 2.16.76.1.3.2 - ICP-Brasil):</strong
+                          >
+                          Nome do respons&#225;vel pelo certificado<a
+                            href="#section-5.2.3.1-8.1.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.3.1-8.2">
+                        <p id="section-5.2.3.1-8.2.1">
+                          <strong
+                            >otherName (OID 2.16.76.1.3.3 - ICP-Brasil):</strong
+                          >
+                          Cadastro Nacional de Pessoa Jur&#237;dica (CNPJ) da
+                          pessoa jur&#237;dica titular do certificado;<a
+                            href="#section-5.2.3.1-8.2.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.3.1-8.3">
+                        <p id="section-5.2.3.1-8.3.1">
+                          <strong
+                            >otherName (OID 2.16.76.1.3.4 - ICP-Brasil):</strong
+                          >
+                          Respons&#225;vel pelo certificado de pessoa
+                          juri&#769;dica titular do certificado (data de
+                          nascimento, CPF, PIS/PASEP/CI, RG);<a
+                            href="#section-5.2.3.1-8.3.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                      <li id="section-5.2.3.1-8.4">
+                        <p id="section-5.2.3.1-8.4.1">
+                          <strong
+                            >otherName (OID 2.16.76.1.3.7 - ICP-Brasil):</strong
+                          >
+                          N&#250;mero do Cadastro Especifico do INSS (CEI) da
+                          pessoa jur&#237;dica titular do certificado.<a
+                            href="#section-5.2.3.1-8.4.1"
+                            class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                    </ul>
+                  </section>
+                </div>
+                <div id="autoridades-certificadoras-participantes">
+                  <section id="section-5.2.3.2">
+                    <h5 id="name-autoridades-certificadoras-">
+                      <a href="#section-5.2.3.2" class="section-number selfRef"
+                        >5.2.3.2. </a
+                      ><a
+                        href="#name-autoridades-certificadoras-"
+                        class="section-name selfRef"
+                        >Autoridades Certificadoras Participantes</a
+                      >
+                    </h5>
+                    <p id="section-5.2.3.2-1">
+                      A lista abaixo representa a lista de autoridades
+                      certificadoras que realizaram o processo de onboard ao
+                      Open Banking Brasil e est&#227;o habilitadas para realizar
+                      a emiss&#227;o de certificados do Open Banking Brasil.<a
+                        href="#section-5.2.3.2-1"
+                        class="pilcrow"
+                        >¶</a
+                      >
+                    </p>
+                    <ul>
+                      <li id="section-5.2.3.2-2.1">
+                        <p id="section-5.2.3.2-2.1.1">
+                          N/A<a href="#section-5.2.3.2-2.1.1" class="pilcrow"
+                            >¶</a
+                          >
+                        </p>
+                      </li>
+                    </ul>
+                  </section>
+                </div>
+              </section>
+            </div>
+            <div id="certificado-para-front-end">
+              <section id="section-5.2.4">
+                <h4 id="name-certificado-para-front-end">
+                  <a href="#section-5.2.4" class="section-number selfRef"
+                    >5.2.4. </a
+                  ><a
+                    href="#name-certificado-para-front-end"
+                    class="section-name selfRef"
+                    >Certificado para Front-End</a
+                  >
+                </h4>
+                <p id="section-5.2.4-1">
+                  Os certificados para Front-End s&#227;o utilziados para
+                  disponibilizar os servi&#231;os, em geral p&#225;ginas Web,
+                  com uso de TLS, na qual s&#227;o acessado por usu&#225;rio
+                  final. Dado a sua finalidade, e para garantir maior
+                  interoperabilidade. Os certificados devem ser do tipo EV
+                  (Extended Validation) e devem ser ser gerados atrav&#233;s de
+                  uma autoridade certificadora v&#225;lida, seguindo as regras
+                  definidas na RFC 5280 e RFC 2818, em conformidade com os
+                  princ&#237;pios e crit&#233;rios WebTrust.<a
+                    href="#section-5.2.4-1"
+                    class="pilcrow"
+                    >¶</a
+                  >
+                </p>
+              </section>
+            </div>
+          </section>
+        </div>
+      </section>
+    </div>
+    <div id="reconhecimento">
+      <section id="section-6">
+        <h2 id="name-reconhecimento">
+          <a href="#section-6" class="section-number selfRef">6. </a
+          ><a href="#name-reconhecimento" class="section-name selfRef"
+            >Reconhecimento</a
+          >
+        </h2>
+        <p id="section-6-1">
+          Agradecemos a todos que estabeleceram as bases para o compartilhamento
+          seguro e seguro de dados por meio da forma&#231;&#227;o do Grupo de
+          Trabalho FAPI da OpenID Foundation, o GT-Seguran&#231;a do Open
+          Banking Brasil e aos pioneiros que ficar&#227;o em seus ombros.<a
+            href="#section-6-1"
+            class="pilcrow"
+            >¶</a
+          >
+        </p>
+        <p id="section-6-2">
+          As seguintes pessoas contribu&#237;ram para este documento:<a
+            href="#section-6-2"
+            class="pilcrow"
+            >¶</a
+          >
+        </p>
+        <ul>
+          <li id="section-6-3.1">
+            <p id="section-6-3.1.1">
+              Marcos Rodrigues (Ita&#250;)<a
+                href="#section-6-3.1.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-6-3.2">
+            <p id="section-6-3.2.1">
+              Jos&#233; Michael Dias (Grupo Pan)<a
+                href="#section-6-3.2.1"
+                class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+          <li id="section-6-3.3">
+            <p id="section-6-3.3.1">
+              Ralph Bragg (Raidiam)<a href="#section-6-3.3.1" class="pilcrow"
+                >¶</a
+              >
+            </p>
+          </li>
+        </ul>
+      </section>
+    </div>
+    <div id="informativo">
+      <section id="section-7">
+        <h2 id="name-informativo">
+          <a href="#section-7" class="section-number selfRef">7. </a
+          ><a href="#name-informativo" class="section-name selfRef"
+            >Informativo</a
+          >
+        </h2>
+        <p id="section-7-1">
+          Copyright (c) 2021 Estrutura Inicial do Open Banking Brasil.<a
+            href="#section-7-1"
+            class="pilcrow"
+            >¶</a
+          >
+        </p>
+        <p id="section-7-2">
+          A Estrutura Inicial do Open Banking Brasil (EIOBB) concede a qualquer
+          Colaborador, desenvolvedor, implementador ou outra parte interessada
+          uma licen&#231;a de direitos autorais mundial n&#227;o exclusiva,
+          livre de royalties para reproduzir, preparar trabalhos derivados,
+          distribuir, executar e exibir, estes Implementadores Rascunho ou
+          Especifica&#231;&#227;o Final exclusivamente para fins de (i)
+          desenvolver especifica&#231;&#245;es e (ii) implementar Rascunhos de
+          Implementa&#231;&#245;es e Especifica&#231;&#245;es Finais com base em
+          tais documentos, desde que a atribui&#231;&#227;o seja feita ao EIOBB
+          como a fonte do material, mas que tal atribui&#231;&#227;o o fa&#231;a
+          n&#227;o indica endosso do EIOBB.<a
+            href="#section-7-2"
+            class="pilcrow"
+            >¶</a
+          >
+        </p>
+        <p id="section-7-3">
+          A tecnologia descrita nesta especifica&#231;&#227;o foi
+          disponibilizada a partir de contribui&#231;&#245;es de v&#225;rias
+          fontes, incluindo membros da OpenID Foundation, do GT-Seguran&#231;a
+          do Open Banking Brasil e outros. Embora a Estrutura Inicial do Open
+          Banking Brasil tenha tomado medidas para ajudar a garantir que a
+          tecnologia esteja dispon&#237;vel para distribui&#231;&#227;o, ela
+          n&#227;o toma posi&#231;&#227;o quanto &#224; validade ou escopo de
+          qualquer propriedade intelectual ou outros direitos que possam ser
+          reivindicados como pertencentes &#224; implementa&#231;&#227;o ou uso
+          do tecnologia descrita nesta especifica&#231;&#227;o ou at&#233; que
+          ponto qualquer licen&#231;a sob tais direitos pode ou n&#227;o estar
+          dispon&#237;vel; nem representa que fez qualquer esfor&#231;o
+          independente para identificar tais direitos. A Estrutura Inicial do
+          Open Banking Brasil e os contribuidores desta especifica&#231;&#227;o
+          n&#227;o oferecem (e por meio deste expressamente se isentam de
+          quaisquer) garantias (expressas, impl&#237;citas ou de outra forma),
+          incluindo garantias impl&#237;citas de comercializa&#231;&#227;o,
+          n&#227;o viola&#231;&#227;o, adequa&#231;&#227;o a uma finalidade
+          espec&#237;fica ou t&#237;tulo, relacionados a esta
+          especifica&#231;&#227;o, e todo o risco quanto &#224;
+          implementa&#231;&#227;o desta especifica&#231;&#227;o &#233; assumido
+          pelo implementador. A pol&#237;tica de Direitos de Propriedade
+          Intelectual do Open Banking Brasil exige que os contribuidores
+          ofere&#231;am uma promessa de patente de n&#227;o fazer valer certas
+          reivindica&#231;&#245;es de patentes contra outros contribuidores e
+          implementadores. A Estrutura Inicial do Open Banking Brasil convida
+          qualquer parte interessada a trazer &#224; sua aten&#231;&#227;o
+          quaisquer direitos autorais, patentes, pedidos de patentes ou outros
+          direitos de propriedade que possam abranger a tecnologia que possa ser
+          necess&#225;ria para praticar esta especifica&#231;&#227;o.<a
+            href="#section-7-3"
+            class="pilcrow"
+            >¶</a
+          >
+        </p>
+      </section>
+    </div>
+    <div id="apendice">
+      <section id="section-8">
+        <h2 id="name-apendice">
+          <a href="#section-8" class="section-number selfRef">8. </a
+          ><a href="#name-apendice" class="section-name selfRef">Apendice</a>
+        </h2>
+        <div id="modelo-de-configuracao-de-certificado-cliente-openssl">
+          <section id="section-8.1">
+            <h3 id="name-modelo-de-configuracao-de-c">
+              <a href="#section-8.1" class="section-number selfRef">8.1. </a
+              ><a
+                href="#name-modelo-de-configuracao-de-c"
+                class="section-name selfRef"
+                >Modelo de Configuracao de Certificado Cliente - OpenSSL</a
+              >
+            </h3>
+            <div class="artwork art-text alignLeft" id="section-8.1-1">
+              <pre>
+[req]
 default_bits = 2048
 default_md = sha256
 encrypt_key = yes
@@ -1588,17 +2565,26 @@ extendedKeyUsage = clientAuth
 
 [ alt_name ]
 DNS = <FQDN|Wildcard>
-</pre><a href="#section-8.1-1" class="pilcrow">¶</a>
-</div>
-</section>
-</div>
-<div id="modelo-de-configuracao-de-certificado-de-assinatura-openssl">
-<section id="section-8.2">
-        <h3 id="name-modelo-de-configuracao-de-ce">
-<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-modelo-de-configuracao-de-ce" class="section-name selfRef">Modelo de Configuracao de Certificado de Assinatura - OpenSSL</a>
-        </h3>
-<div class="artwork art-text alignLeft" id="section-8.2-1">
-<pre>[req]
+</pre
+              >
+              <a href="#section-8.1-1" class="pilcrow">¶</a>
+            </div>
+          </section>
+        </div>
+        <div id="modelo-de-configuracao-de-certificado-de-assinatura-openssl">
+          <section id="section-8.2">
+            <h3 id="name-modelo-de-configuracao-de-ce">
+              <a href="#section-8.2" class="section-number selfRef">8.2. </a
+              ><a
+                href="#name-modelo-de-configuracao-de-ce"
+                class="section-name selfRef"
+                >Modelo de Configuracao de Certificado de Assinatura -
+                OpenSSL</a
+              >
+            </h3>
+            <div class="artwork art-text alignLeft" id="section-8.2-1">
+              <pre>
+[req]
 default_bits = 2048
 default_md = sha256
 encrypt_key = yes
@@ -1626,19 +2612,22 @@ otherName.0 = 2.16.76.1.3.2;UTF8:<Nome da pessoal responsável pela entidade>#CN
 otherName.1 = 2.16.76.1.3.3;UTF8<CNPJ>
 otherName.2 = 2.16.76.1.3.4;UTF8:<CPF/PIS/RF da Pessoa responsável>
 otherName.3 = 2.16.76.1.3.7;UTF8:<Número de INSS>
-</pre><a href="#section-8.2-1" class="pilcrow">¶</a>
-</div>
-</section>
-</div>
-</section>
-</div>
-<script>const toc = document.getElementById("toc");
-toc.querySelector("h2").addEventListener("click", e => {
-  toc.classList.toggle("active");
-});
-toc.querySelector("nav").addEventListener("click", e => {
-  toc.classList.remove("active");
-});
-</script>
-</body>
+</pre
+              >
+              <a href="#section-8.2-1" class="pilcrow">¶</a>
+            </div>
+          </section>
+        </div>
+      </section>
+    </div>
+    <script>
+      const toc = document.getElementById("toc");
+      toc.querySelector("h2").addEventListener("click", (e) => {
+        toc.classList.toggle("active");
+      });
+      toc.querySelector("nav").addEventListener("click", (e) => {
+        toc.classList.remove("active");
+      });
+    </script>
+  </body>
 </html>

--- a/open-banking-brasil-certificate-standards-1_ID1.md
+++ b/open-banking-brasil-certificate-standards-1_ID1.md
@@ -110,7 +110,7 @@ Para o propósito deste documento os termos definidos na [RFC5280, [BCP195], [RF
 
 O sistema de Open Banking Brasil faz uso de cadeias de certificados e protocolo TLS para garantir a confidencialidade, autenticação e integridade do canal de comunicação utilizado pelas APIs das instituições participantes do Ecossistema bem como dos clientes de cada um dos participantes.
 
-Os certificados utilizados para o Open Banking Brasil também são necessários para autenticar as aplicações através do oAuth 2.0 mTLS ou private_key_jwt, além de també servirem para realizar a assinatura de payload pelo uso de JWS. Outra atribuição importante dos certificados é realizar a autenticação e apresentar um canal seguro para o consumidor final no ato de autenticação e uso dos serviços prestados pela entidade participante.
+Os certificados utilizados para o Open Banking Brasil também são necessários para autenticar as aplicações através do oAuth 2.0 mTLS ou private_key_jwt, além de também servirem para realizar a assinatura de payload pelo uso de JWS. Outra atribuição importante dos certificados é realizar a autenticação e apresentar um canal seguro para o usuário final no ato de autenticação e uso dos serviços prestados pela entidade participante.
 
 ## Certificados ICP-Brasil
 
@@ -136,9 +136,9 @@ O padrão de certificado utilizado deve seguir as práticas de emissão de certi
 
 ### Certificado Cliente
 
-Os certificados de Open Banking, denominados Certificado de Aplicação Cliente (Transporte) são utilizados para autenticar o canal MTLS.  Os Certificado Cliente também são utilizados para realizar a autenticação da aplicação cliente através de oAuth 2.0 mTLS ou private_key_jwt, de acordo com cadastro da aplicação realizado o processo de Dynamic Client Registration junto a entidade transmissora.
+Os certificados de Open Banking, denominados Certificado de Aplicação Cliente (Transporte) são utilizados para autenticar o canal MTLS. Os Certificados Cliente também são utilizados para realizar a autenticação da aplicação cliente através de oAuth2.0 mTLS ou private_key_jwt, de acordo com cadastro da aplicação realizado o processo de Dynamic Client Registration junto a entidade transmissora.
 
-Para emissão de certificado de cliente é necessário que a instituição participante do Open Banking Brasil tenha realizado o cadastro de aplicação ao diretório, através da emissão de Software Statement Assertion, e com isso já tenha obtido o valor de Software Statement ID.
+Para emissão de certificado de cliente é necessário que a instituição participante do Open Banking Brasil tenha realizado o cadastro de aplicação ao diretório, através do processo de emissão de Software Statement Assertion, e com isso já tenha obtido o valor de Software Statement ID.
 
 #### Atributos OpenBanking Brasil
 
@@ -204,14 +204,13 @@ O Certificado de Assinatura deve ser emitido através de cadeia V5, e deve obrig
 
 #### Autoridades Certificadoras Participantes
 
-A lista abaixa representa a lista de autoridades certificadoras que realizaram o processo de onboard ao Open Banking Brasil e estão habilitadas para realizar a emissão de certificados do Open Banking Brasil.
+A lista abaixo representa a lista de autoridades certificadoras que realizaram o processo de onboard ao Open Banking Brasil e estão habilitadas para realizar a emissão de certificados do Open Banking Brasil.
 
 * N/A
 
 ### Certificado para Front-End
 
-Os certificados para Front-End são utilziados para disponibilizar os serviços, em geral páginas Web, com uso de TLS, na qual são acessado por usuário final. Dado a sua finalidade, e para garantir maior interoperabilidade. Os certificados devem ser do tipo EV (Extended Validation) e deve ser ser gerado através de uma autoridade certificadora válida,
-seguindo as regras definidas na RFC 5280 e RFC 2818, em conformidade com os princípios e critérios WebTrust.
+Os certificados para Front-End são utilziados para disponibilizar os serviços, em geral páginas Web, com uso de TLS, na qual são acessado por usuário final. Dado a sua finalidade, e para garantir maior interoperabilidade. Os certificados devem ser do tipo EV (Extended Validation) e devem ser ser gerados através de uma autoridade certificadora válida, seguindo as regras definidas na RFC 5280 e RFC 2818, em conformidade com os princípios e critérios WebTrust.
 
 # Reconhecimento
 

--- a/open-banking-brasil-certificate-standards-1_ID1.xml
+++ b/open-banking-brasil-certificate-standards-1_ID1.xml
@@ -117,7 +117,7 @@
 
 <section anchor="introducao"><name>Introducao</name>
 <t>O sistema de Open Banking Brasil faz uso de cadeias de certificados e protocolo TLS para garantir a confidencialidade, autenticação e integridade do canal de comunicação utilizado pelas APIs das instituições participantes do Ecossistema bem como dos clientes de cada um dos participantes.</t>
-<t>Os certificados utilizados para o Open Banking Brasil também são necessários para autenticar as aplicações através do oAuth 2.0 mTLS ou private<em>key</em>jwt, além de també servirem para realizar a assinatura de payload pelo uso de JWS. Outra atribuição importante dos certificados é realizar a autenticação e apresentar um canal seguro para o consumidor final no ato de autenticação e uso dos serviços prestados pela entidade participante.</t>
+<t>Os certificados utilizados para o Open Banking Brasil também são necessários para autenticar as aplicações através do oAuth 2.0 mTLS ou private<em>key</em>jwt, além de também servirem para realizar a assinatura de payload pelo uso de JWS. Outra atribuição importante dos certificados é realizar a autenticação e apresentar um canal seguro para o usuário final no ato de autenticação e uso dos serviços prestados pela entidade participante.</t>
 </section>
 
 <section anchor="certificados-icp-brasil"><name>Certificados ICP-Brasil</name>
@@ -142,8 +142,8 @@
 </section>
 
 <section anchor="certificado-cliente"><name>Certificado Cliente</name>
-<t>Os certificados de Open Banking, denominados Certificado de Aplicação Cliente (Transporte) são utilizados para autenticar o canal MTLS.  Os Certificado Cliente também são utilizados para realizar a autenticação da aplicação cliente através de oAuth 2.0 mTLS ou private<em>key</em>jwt, de acordo com cadastro da aplicação realizado o processo de Dynamic Client Registration junto a entidade transmissora.</t>
-<t>Para emissão de certificado de cliente é necessário que a instituição participante do Open Banking Brasil tenha realizado o cadastro de aplicação ao diretório, através da emissão de Software Statement Assertion, e com isso já tenha obtido o valor de Software Statement ID.</t>
+<t>Os certificados de Open Banking, denominados Certificado de Aplicação Cliente (Transporte) são utilizados para autenticar o canal MTLS. Os Certificados Cliente também são utilizados para realizar a autenticação da aplicação cliente através de oAuth2.0 mTLS ou private<em>key</em>jwt, de acordo com cadastro da aplicação realizado o processo de Dynamic Client Registration junto a entidade transmissora.</t>
+<t>Para emissão de certificado de cliente é necessário que a instituição participante do Open Banking Brasil tenha realizado o cadastro de aplicação ao diretório, através do processo de emissão de Software Statement Assertion, e com isso já tenha obtido o valor de Software Statement ID.</t>
 
 <section anchor="atributos-openbanking-brasil"><name>Atributos OpenBanking Brasil</name>
 
@@ -248,7 +248,7 @@
 </section>
 
 <section anchor="autoridades-certificadoras-participantes"><name>Autoridades Certificadoras Participantes</name>
-<t>A lista abaixa representa a lista de autoridades certificadoras que realizaram o processo de onboard ao Open Banking Brasil e estão habilitadas para realizar a emissão de certificados do Open Banking Brasil.</t>
+<t>A lista abaixo representa a lista de autoridades certificadoras que realizaram o processo de onboard ao Open Banking Brasil e estão habilitadas para realizar a emissão de certificados do Open Banking Brasil.</t>
 
 <ul>
 <li><t>N/A</t>
@@ -258,8 +258,7 @@
 </section>
 
 <section anchor="certificado-para-front-end"><name>Certificado para Front-End</name>
-<t>Os certificados para Front-End são utilziados para disponibilizar os serviços, em geral páginas Web, com uso de TLS, na qual são acessado por usuário final. Dado a sua finalidade, e para garantir maior interoperabilidade. Os certificados devem ser do tipo EV (Extended Validation) e deve ser ser gerado através de uma autoridade certificadora válida,
-seguindo as regras definidas na RFC 5280 e RFC 2818, em conformidade com os princípios e critérios WebTrust.</t>
+<t>Os certificados para Front-End são utilziados para disponibilizar os serviços, em geral páginas Web, com uso de TLS, na qual são acessado por usuário final. Dado a sua finalidade, e para garantir maior interoperabilidade. Os certificados devem ser do tipo EV (Extended Validation) e devem ser ser gerados através de uma autoridade certificadora válida, seguindo as regras definidas na RFC 5280 e RFC 2818, em conformidade com os princípios e critérios WebTrust.</t>
 </section>
 </section>
 </section>

--- a/open-banking-brasil-financial-api-1_ID1.html
+++ b/open-banking-brasil-financial-api-1_ID1.html
@@ -1405,6 +1405,9 @@ In addition this profile describes the specific scope, acr and client management
 <li id="section-5.2.2-3.12">
               <p id="section-5.2.2-3.12.1">shall support refresh tokens<a href="#section-5.2.2-3.12.1" class="pilcrow">¶</a></p>
 </li>
+<li id="section-5.2.2-3.13">
+              <p id="section-5.2.2-3.13.1">shall issue access tokens with an expiry no greater than 900 seconds and no less than 300 seconds<a href="#section-5.2.2-3.13.1" class="pilcrow">¶</a></p>
+</li>
 </ol>
 <div id="id-token-as-detached-signature">
 <section id="section-5.2.2.1">

--- a/open-banking-brasil-financial-api-1_ID1.html
+++ b/open-banking-brasil-financial-api-1_ID1.html
@@ -1071,7 +1071,7 @@ tr:nth-child(2n+1) > td {
 <td class="right">May 2021</td>
 </tr></thead>
 <tfoot><tr>
-<td class="left">Bragg &; Security</td>
+<td class="left">Bragg & Security</td>
 <td class="center">Standards Track</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
@@ -1085,7 +1085,7 @@ tr:nth-child(2n+1) > td {
 <dd class="internet-draft">open-banking-brasil-financial-api-1_ID1</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-05-20" class="published">20 May 2021</time>
+<time datetime="2021-05-27" class="published">27 May 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
@@ -1228,21 +1228,13 @@ and are not to be interpreted with their natural language meanings.<a href="#sec
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-regulatory-considerations" class="xref">Regulatory Considerations</a><a href="#section-toc.1-1.8.1" class="pilcrow">¶</a></p>
-<ul class="toc ulEmpty">
-<li class="toc ulEmpty" id="section-toc.1-1.8.2.1">
-                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-requirement-on-client-to-pr" class="xref">Requirement on Client to present cpf claim to AS</a><a href="#section-toc.1-1.8.2.1.1" class="pilcrow">¶</a></p>
-</li>
-</ul>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a><a href="#section-toc.1-1.8.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a><a href="#section-toc.1-1.9.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-notices" class="xref">Notices</a><a href="#section-toc.1-1.9.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-notices" class="xref">Notices</a><a href="#section-toc.1-1.10.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.11.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.10.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.10.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </nav>
@@ -1411,10 +1403,7 @@ In addition this profile describes the specific scope, acr and client management
               <p id="section-5.2.2-3.11.1">shall support <a href="https://bitbucket.org/openid/fapi/src/master/Financial_API_WD_CIBA.md">Financial-grade API: Client Initiated Backchannel Authentication Profile</a> if supporting scope <em>payments</em><a href="#section-5.2.2-3.11.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-5.2.2-3.12">
-              <p id="section-5.2.2-3.12.1">may require the presence of a populated cpf value claim if scope includes dynamic resource scope <em>consent</em><a href="#section-5.2.2-3.12.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-5.2.2-3.13">
-              <p id="section-5.2.2-3.13.1">shall support refresh tokens<a href="#section-5.2.2-3.13.1" class="pilcrow">¶</a></p>
+              <p id="section-5.2.2-3.12.1">shall support refresh tokens<a href="#section-5.2.2-3.12.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
 <div id="id-token-as-detached-signature">
@@ -1439,7 +1428,7 @@ then it shall encrypt the ID Token.<a href="#section-5.2.2.1-3.1.1" class="pilcr
             </h5>
 <p id="section-5.2.2.2-1">This profile defines "cpf" as a new standard claim as per
  clause 5.1 <a href="https://openid.net/specs/openid-connect-core-1_0.html">OIDC</a><a href="#section-5.2.2.2-1" class="pilcrow">¶</a></p>
-<p id="section-5.2.2.2-2">The <strong>CPF</strong> number (Cadastro de Pessoas F&;#237;sicas, [sepe&;#712;&;#603;fi]; Portuguese for "Natural Persons Register")
+<p id="section-5.2.2.2-2">The <strong>CPF</strong> number (Cadastro de Pessoas F&#237;sicas, [sepe&#712;&#603;fi]; Portuguese for "Natural Persons Register")
  is the <strong>Brazilian</strong> individual taxpayer registry identification. This number is attributed by
  the <strong>Brazilian</strong> Federal Revenue to Brazilians and resident aliens who, directly or indirectly,
   pay taxes in <strong>Brazil</strong>.
@@ -1459,9 +1448,9 @@ that matches the requested value. If this is an Essential Claim and the requirem
             </h5>
 <p id="section-5.2.2.3-1">This profile defines "cnpj" as a new standard claim as per
  clause 5.1<a href="https://openid.net/specs/openid-connect-core-1_0.html">OIDC</a><a href="#section-5.2.2.3-1" class="pilcrow">¶</a></p>
-<p id="section-5.2.2.3-2"><strong>CNPJ</strong>, short for Cadastro Nacional de Pessoas Jur&;#237;dicas, is an identification number
+<p id="section-5.2.2.3-2"><strong>CNPJ</strong>, short for Cadastro Nacional de Pessoas Jur&#237;dicas, is an identification number
  of <strong>Brazilian</strong> companies issued by the <strong>Brazilian</strong> Ministry of Revenue, <strong>in</strong>
- Portuguese "Secretaria da Receita Federal" or "Minist&;#233;rio da Fazenda". In the Brasil Open Banking identity model,
+ Portuguese "Secretaria da Receita Federal" or "Minist&#233;rio da Fazenda". In the Brasil Open Banking identity model,
  individuals can associated with 0 or more CNPJs. A CNPJ is a string consisting of numbers that is 14 digits long and may start with a 0,
  the first eight digits identify the company, the four digits after the slash identify the branch or
   subsidiary ("0001" defaults to the headquarters), and the last two are checksum digits.
@@ -1540,9 +1529,6 @@ Claim Value that contains a <strong>set</strong> of CNPJs one of which must matc
 <li id="section-5.2.3-3.5">
               <p id="section-5.2.3-3.5.1">shall support refresh tokens<a href="#section-5.2.3-3.5.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-5.2.3-3.6">
-              <p id="section-5.2.3-3.6.1">shall include a populated cpf value claim if scope includes dynamic resource scope <em>consent</em><a href="#section-5.2.3-3.6.1" class="pilcrow">¶</a></p>
-</li>
 </ol>
 </section>
 </div>
@@ -1556,7 +1542,7 @@ Claim Value that contains a <strong>set</strong> of CNPJs one of which must matc
 <a href="#section-6" class="section-number selfRef">6. </a><a href="#name-security-considerations" class="section-name selfRef">Security considerations</a>
       </h2>
 <p id="section-6-1">Participants shall support all security considerations specified in clause 8
- <a href="https://openid.net/specs/openid-financial-api-part-2-1_0.html">Financial-grade API Security Profile 1.0 - Part 1: Advanced</a> and the <a href="https://www.bcb.gov.br/estabilidadefinanceira/exibenormativo?tipo=Instru%C3%A7%C3%A3o%20Normativa%20BCB&;numero=99">Brazilian Central Bank Open Banking Security Manual</a>.
+ <a href="https://openid.net/specs/openid-financial-api-part-2-1_0.html">Financial-grade API Security Profile 1.0 - Part 1: Advanced</a> and the <a href="https://www.bcb.gov.br/estabilidadefinanceira/exibenormativo?tipo=Instru%C3%A7%C3%A3o%20Normativa%20BCB&numero=99">Brazilian Central Bank Open Banking Security Manual</a>.
  The Brazilian ICP issues RSA x509 certificates only therefor section removes for simplicity support for EC algorithms
  and requires that only IANA recommended encryption algorithms be used.<a href="#section-6-1" class="pilcrow">¶</a></p>
 <div id="algorithm-considerations">
@@ -1683,16 +1669,22 @@ Claim Value that contains a <strong>set</strong> of CNPJs one of which must matc
 <p id="section-7.2.2-1">In addition to the requirements outlined in Open Banking Brasil security provisions the Authorization Server<a href="#section-7.2.2-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-7.2.2-2">
             <li id="section-7.2.2-2.1">
-              <p id="section-7.2.2-2.1.1">shall revoke refresh tokens and where practicable access tokens when the linked Consent Resource is deleted;<a href="#section-7.2.2-2.1.1" class="pilcrow">¶</a></p>
+              <p id="section-7.2.2-2.1.1">shall issue refresh tokens with validity equal to the <em>expirationDateTime</em> defined on the linked Consent Resource;<a href="#section-7.2.2-2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-7.2.2-2.2">
-              <p id="section-7.2.2-2.2.1">shall ensure Access Tokens are issued with sufficient scope necessary for access to data specified in the Permissions element of a linked Consent Resource object;<a href="#section-7.2.2-2.2.1" class="pilcrow">¶</a></p>
+              <p id="section-7.2.2-2.2.1">shall revoke refresh tokens and where practicable access tokens when the linked Consent Resource is deleted;<a href="#section-7.2.2-2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-7.2.2-2.3">
-              <p id="section-7.2.2-2.3.1">shall not reject an authorisation request requesting more scope than is necessary to access data specified in the Permissions element of a linked Consent Resource object;<a href="#section-7.2.2-2.3.1" class="pilcrow">¶</a></p>
+              <p id="section-7.2.2-2.3.1">shall ensure Access Tokens are issued with sufficient scope necessary for access to data specified in the Permissions element of a linked Consent Resource object;<a href="#section-7.2.2-2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-7.2.2-2.4">
-              <p id="section-7.2.2-2.4.1">may reduce requested scope to a level sufficient to enable access to data resources specified in the Permissions element of a linked Consent Resource object;<a href="#section-7.2.2-2.4.1" class="pilcrow">¶</a></p>
+              <p id="section-7.2.2-2.4.1">shall not reject an authorisation request requesting more scope than is necessary to access data specified in the Permissions element of a linked Consent Resource object;<a href="#section-7.2.2-2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-7.2.2-2.5">
+              <p id="section-7.2.2-2.5.1">may reduce requested scope to a level sufficient to enable access to data resources specified in the Permissions element of a linked Consent Resource object;<a href="#section-7.2.2-2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-7.2.2-2.6">
+              <p id="section-7.2.2-2.6.1">shall retain a complete audit history of the consent resource in acoordance with current Central Bank brazilian regulation;<a href="#section-7.2.2-2.6.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
 </section>
@@ -1717,47 +1709,25 @@ Claim Value that contains a <strong>set</strong> of CNPJs one of which must matc
 </div>
 </section>
 </div>
-<div id="regulatory-considerations">
-<section id="section-8">
-      <h2 id="name-regulatory-considerations">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-regulatory-considerations" class="section-name selfRef">Regulatory Considerations</a>
-      </h2>
-<div id="Reg">
-<section id="section-8.1">
-        <h3 id="name-requirement-on-client-to-pr">
-<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-requirement-on-client-to-pr" class="section-name selfRef">Requirement on Client to present cpf claim to AS</a>
-        </h3>
-<p id="section-8.1-1"><a href="https://www.in.gov.br/en/web/dou/-/resolucao-conjunta-n-1-de-4-de-maio-de-2020-255165055">Joint Resolution No 1, Art. 10, paragraph VI</a>
-The interpretation of the Compliance team requires the TPPs to identify the customer before requesting access to resources from a bank. The mechanism adopted is to require the TPP to include a populated customer cpf claim as part of a request object when the request to the bank includes a request for access to a account or payment resources which is
- conveyed by a dynamic scope of 'consent:{consentId}'.<a href="#section-8.1-1" class="pilcrow">¶</a></p>
-<p id="section-8.1-2">This assertion is considered to be sufficient to meet the requirements of the legislation but does result in the requirement for customers to provide to third parties this information ahead of requesting an open banking flow.
- Banks that wish to prevent poor customer experiences or help mitigate the need for customers to key in sensitive details into third party UIs can provide the cpf and other attributes as part of a consent journey
- provided that they do so without also accepting a request for data sharing at the same time.<a href="#section-8.1-2" class="pilcrow">¶</a></p>
-<p id="section-8.1-3">The sharing of customer atttributes without a corresponding open banking resource sharing request is out of scope of the regulation which means that banks are not obliged to offer this service but there is no technical barrier with them doing.
-The security profile has been specifically drafted to enable and encourage banks to facilitate this two step process which significantly improves the new customer experience for tpps and prevents the bad practice of encouraging consumers to manually share sentitive personal information into websites. Removing the need for this activity is one of the primary security goals of Open Banking and the OpenID Foundation Financial Grade Working Group on whose standards this profile is based.<a href="#section-8.1-3" class="pilcrow">¶</a></p>
-</section>
-</div>
-</section>
-</div>
 <div id="acknowledgements">
-<section id="section-9">
+<section id="section-8">
       <h2 id="name-acknowledgements">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<p id="section-9-1">With thanks to all who have set the foundations for secure and safe data sharing through the formation of the OpenID Foundation FAPI Working Group, the Open Banking Brasil GT Security and to the pioneers who will stand on their shoulders.<a href="#section-9-1" class="pilcrow">¶</a></p>
-<p id="section-9-2">The following people contributed to this document:<a href="#section-9-2" class="pilcrow">¶</a></p>
+<p id="section-8-1">With thanks to all who have set the foundations for secure and safe data sharing through the formation of the OpenID Foundation FAPI Working Group, the Open Banking Brasil GT Security and to the pioneers who will stand on their shoulders.<a href="#section-8-1" class="pilcrow">¶</a></p>
+<p id="section-8-2">The following people contributed to this document:<a href="#section-8-2" class="pilcrow">¶</a></p>
 <ul>
-<li id="section-9-3.1">
-          <p id="section-9-3.1.1">Ralph Bragg (Raidiam)<a href="#section-9-3.1.1" class="pilcrow">¶</a></p>
+<li id="section-8-3.1">
+          <p id="section-8-3.1.1">Ralph Bragg (Raidiam)<a href="#section-8-3.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-9-3.2">
-          <p id="section-9-3.2.1">Joseph Heenan (Authlete)<a href="#section-9-3.2.1" class="pilcrow">¶</a></p>
+<li id="section-8-3.2">
+          <p id="section-8-3.2.1">Joseph Heenan (Authlete)<a href="#section-8-3.2.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-9-3.3">
-          <p id="section-9-3.3.1">Alexandre Siqueira (Mercado Pago)<a href="#section-9-3.3.1" class="pilcrow">¶</a></p>
+<li id="section-8-3.3">
+          <p id="section-8-3.3.1">Alexandre Siqueira (Mercado Pago)<a href="#section-8-3.3.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-9-3.4">
-          <p id="section-9-3.4.1">Marcos Rodrigues (Ita&;#250;)<a href="#section-9-3.4.1" class="pilcrow">¶</a></p>
+<li id="section-8-3.4">
+          <p id="section-8-3.4.1">Marcos Rodrigues (Ita&#250;)<a href="#section-8-3.4.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </section>

--- a/open-banking-brasil-financial-api-1_ID1.html
+++ b/open-banking-brasil-financial-api-1_ID1.html
@@ -1643,7 +1643,7 @@ Claim Value that contains a <strong>set</strong> of CNPJs one of which must matc
           <h4 id="name-dynamic-consent-scope-examp">
 <a href="#section-7.1.3" class="section-number selfRef">7.1.3. </a><a href="#name-dynamic-consent-scope-examp" class="section-name selfRef">Dynamic Consent Scope Example</a>
           </h4>
-<p id="section-7.1.3-1">consent:urn-bancoex-C1DD33123<a href="#section-7.1.3-1" class="pilcrow">¶</a></p>
+<p id="section-7.1.3-1">consent:urn:bancoex:C1DD33123<a href="#section-7.1.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>

--- a/open-banking-brasil-financial-api-1_ID1.md
+++ b/open-banking-brasil-financial-api-1_ID1.md
@@ -218,6 +218,7 @@ In addition, the Authorization Server
 10. may support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA]
 11. shall support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] if supporting scope _payments_
 12. shall support refresh tokens
+13. shall issue access tokens with an expiry no greater than 900 seconds and no less than 300 seconds
 
 #### ID Token as detached signature
 

--- a/open-banking-brasil-financial-api-1_ID1.md
+++ b/open-banking-brasil-financial-api-1_ID1.md
@@ -353,7 +353,7 @@ In addition:
 
 ### Dynamic Consent Scope Example
 
-consent:urn-bancoex-C1DD33123
+consent:urn:bancoex:C1DD33123
 
 ## Authorisation Life Cycle
 

--- a/open-banking-brasil-financial-api-1_ID1.md
+++ b/open-banking-brasil-financial-api-1_ID1.md
@@ -217,8 +217,7 @@ In addition, the Authorization Server
 9. shall support parameterized OAuth 2.0 resource scope _consent_ as defined in clause 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 10. may support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA]
 11. shall support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] if supporting scope _payments_
-12. may require the presence of a populated cpf value claim if scope includes dynamic resource scope _consent_
-13. shall support refresh tokens
+12. shall support refresh tokens
 
 #### ID Token as detached signature
 
@@ -303,7 +302,6 @@ In addition, the confidential client
 3. shall use _encrypted_ request objects if not using [PAR]
 4. shall support parameterized OAuth 2.0 resource scope _consent_ as defined in clause 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 5. shall support refresh tokens
-6. shall include a populated cpf value claim if scope includes dynamic resource scope _consent_
 
 # Security considerations
 
@@ -367,10 +365,12 @@ The Consent Resource has a life cycle that is managed seperately and distinctly 
 
 In addition to the requirements outlined in Open Banking Brasil security provisions the Authorization Server
 
-1. shall revoke refresh tokens and where practicable access tokens when the linked Consent Resource is deleted;
-2. shall ensure Access Tokens are issued with sufficient scope necessary for access to data specified in the Permissions element of a linked Consent Resource object;
-3. shall not reject an authorisation request requesting more scope than is necessary to access data specified in the Permissions element of a linked Consent Resource object;
-4. may reduce requested scope to a level sufficient to enable access to data resources specified in the Permissions element of a linked Consent Resource object;
+1. shall issue refresh tokens with validity equal to the *expirationDateTime* defined on the linked Consent Resource;
+2. shall revoke refresh tokens and where practicable access tokens when the linked Consent Resource is deleted;
+3. shall ensure Access Tokens are issued with sufficient scope necessary for access to data specified in the Permissions element of a linked Consent Resource object;
+4. shall not reject an authorisation request requesting more scope than is necessary to access data specified in the Permissions element of a linked Consent Resource object;
+5. may reduce requested scope to a level sufficient to enable access to data resources specified in the Permissions element of a linked Consent Resource object;
+6. shall retain a complete audit history of the consent resource in acoordance with current Central Bank brazilian regulation;
 
 ### Confidential Client
 
@@ -378,21 +378,6 @@ In addition to the requirements outlined in Open Banking Brasil security provisi
 
 1. shall revoke where possible and cease usage of refresh and access tokens that are bound to a Consent Resource that has been deleted;
 1. shall delete Consent Resource that are expired;
-
-# Regulatory Considerations
-
-## Requirement on Client to present cpf claim to AS {#Reg}
-
-[Joint Resolution No 1, Art. 10, paragraph VI](https://www.in.gov.br/en/web/dou/-/resolucao-conjunta-n-1-de-4-de-maio-de-2020-255165055)
-The interpretation of the Compliance team requires the TPPs to identify the customer before requesting access to resources from a bank. The mechanism adopted is to require the TPP to include a populated customer cpf claim as part of a request object when the request to the bank includes a request for access to a account or payment resources which is
- conveyed by a dynamic scope of 'consent:{consentId}'.
-
-This assertion is considered to be sufficient to meet the requirements of the legislation but does result in the requirement for customers to provide to third parties this information ahead of requesting an open banking flow.
- Banks that wish to prevent poor customer experiences or help mitigate the need for customers to key in sensitive details into third party UIs can provide the cpf and other attributes as part of a consent journey
- provided that they do so without also accepting a request for data sharing at the same time.
-
-The sharing of customer atttributes without a corresponding open banking resource sharing request is out of scope of the regulation which means that banks are not obliged to offer this service but there is no technical barrier with them doing.
-The security profile has been specifically drafted to enable and encourage banks to facilitate this two step process which significantly improves the new customer experience for tpps and prevents the bad practice of encouraging consumers to manually share sentitive personal information into websites. Removing the need for this activity is one of the primary security goals of Open Banking and the OpenID Foundation Financial Grade Working Group on whose standards this profile is based.
 
 # Acknowledgements
 

--- a/open-banking-brasil-financial-api-1_ID1.xml
+++ b/open-banking-brasil-financial-api-1_ID1.xml
@@ -165,6 +165,8 @@ In addition this profile describes the specific scope, acr and client management
 </li>
 <li><t>shall support refresh tokens</t>
 </li>
+<li><t>shall issue access tokens with an expiry no greater than 900 seconds and no less than 300 seconds</t>
+</li>
 </ol>
 
 <section anchor="id-token-as-detached-signature"><name>ID Token as detached signature</name>
@@ -334,7 +336,7 @@ Claim Value that contains a <strong>set</strong> of CNPJs one of which must matc
 </section>
 
 <section anchor="dynamic-consent-scope-example"><name>Dynamic Consent Scope Example</name>
-<t>consent:urn-bancoex-C1DD33123</t>
+<t>consent:urn:bancoex:C1DD33123</t>
 </section>
 </section>
 

--- a/open-banking-brasil-financial-api-1_ID1.xml
+++ b/open-banking-brasil-financial-api-1_ID1.xml
@@ -163,8 +163,6 @@ In addition this profile describes the specific scope, acr and client management
 </li>
 <li><t>shall support <eref target="https://bitbucket.org/openid/fapi/src/master/Financial_API_WD_CIBA.md">Financial-grade API: Client Initiated Backchannel Authentication Profile</eref> if supporting scope <em>payments</em></t>
 </li>
-<li><t>may require the presence of a populated cpf value claim if scope includes dynamic resource scope <em>consent</em></t>
-</li>
 <li><t>shall support refresh tokens</t>
 </li>
 </ol>
@@ -263,8 +261,6 @@ Claim Value that contains a <strong>set</strong> of CNPJs one of which must matc
 </li>
 <li><t>shall support refresh tokens</t>
 </li>
-<li><t>shall include a populated cpf value claim if scope includes dynamic resource scope <em>consent</em></t>
-</li>
 </ol>
 </section>
 </section>
@@ -352,6 +348,8 @@ Claim Value that contains a <strong>set</strong> of CNPJs one of which must matc
 <t>In addition to the requirements outlined in Open Banking Brasil security provisions the Authorization Server</t>
 
 <ol>
+<li><t>shall issue refresh tokens with validity equal to the <em>expirationDateTime</em> defined on the linked Consent Resource;</t>
+</li>
 <li><t>shall revoke refresh tokens and where practicable access tokens when the linked Consent Resource is deleted;</t>
 </li>
 <li><t>shall ensure Access Tokens are issued with sufficient scope necessary for access to data specified in the Permissions element of a linked Consent Resource object;</t>
@@ -359,6 +357,8 @@ Claim Value that contains a <strong>set</strong> of CNPJs one of which must matc
 <li><t>shall not reject an authorisation request requesting more scope than is necessary to access data specified in the Permissions element of a linked Consent Resource object;</t>
 </li>
 <li><t>may reduce requested scope to a level sufficient to enable access to data resources specified in the Permissions element of a linked Consent Resource object;</t>
+</li>
+<li><t>shall retain a complete audit history of the consent resource in acoordance with current Central Bank brazilian regulation;</t>
 </li>
 </ol>
 </section>
@@ -373,20 +373,6 @@ Claim Value that contains a <strong>set</strong> of CNPJs one of which must matc
 </li>
 </ol>
 </section>
-</section>
-</section>
-
-<section anchor="regulatory-considerations"><name>Regulatory Considerations</name>
-
-<section anchor="Reg"><name>Requirement on Client to present cpf claim to AS</name>
-<t><eref target="https://www.in.gov.br/en/web/dou/-/resolucao-conjunta-n-1-de-4-de-maio-de-2020-255165055">Joint Resolution No 1, Art. 10, paragraph VI</eref>
-The interpretation of the Compliance team requires the TPPs to identify the customer before requesting access to resources from a bank. The mechanism adopted is to require the TPP to include a populated customer cpf claim as part of a request object when the request to the bank includes a request for access to a account or payment resources which is
- conveyed by a dynamic scope of 'consent:{consentId}'.</t>
-<t>This assertion is considered to be sufficient to meet the requirements of the legislation but does result in the requirement for customers to provide to third parties this information ahead of requesting an open banking flow.
- Banks that wish to prevent poor customer experiences or help mitigate the need for customers to key in sensitive details into third party UIs can provide the cpf and other attributes as part of a consent journey
- provided that they do so without also accepting a request for data sharing at the same time.</t>
-<t>The sharing of customer atttributes without a corresponding open banking resource sharing request is out of scope of the regulation which means that banks are not obliged to offer this service but there is no technical barrier with them doing.
-The security profile has been specifically drafted to enable and encourage banks to facilitate this two step process which significantly improves the new customer experience for tpps and prevents the bad practice of encouraging consumers to manually share sentitive personal information into websites. Removing the need for this activity is one of the primary security goals of Open Banking and the OpenID Foundation Financial Grade Working Group on whose standards this profile is based.</t>
 </section>
 </section>
 


### PR DESCRIPTION
This pull request addresses the following changes:

- Incorporates language changes for the certificate profile as requested by Marcos.
- Reverts the consentId example to an example provided in the ConsentAPI.
- Removes the requirement for TPPs to Pass the CPF or CNPJ claim.
- Retains the requirement for Banks to support the cpf and cnpj claim as an openid standard claim.
- Removes the regulatory requirements section as the Justification is no longer considered regulatory requirement.
- Ensures that a refresh token has a maximum and minimum validity based on the expirationDateTime of the Consent Payload.
- Limits a maximum validity of an access token to 15 minutes even though they are sender constrained.
- Adds the requirement to retain audit history of the consent resource as per central bank requirements