### PR TITLE
bug/112 pt_BR

### DIFF
--- a/all-documents.md
+++ b/all-documents.md
@@ -119,6 +119,127 @@ As palavras-chave "*deve*" (shall), "*não deve*" (shall not), "*deveria*" (shou
 
 Estas palavras-chave não são usadas como termos de dicionário, de modo que qualquer ocorrência deles deve ser interpretada como palavras-chave e não devem ser interpretados com seus significados de linguagem natural.
 
+## Referências normativas  {#Normative}
+
+Os seguintes documentos referenciados são indispensáveis para a adoção das especificações deste documento. Para referências datadas, apenas a edição citada se aplica. Para referências não datadas, deve-se aplicar a última edição do documento referenciado (incluindo quaisquer emendas).
+
+[ISODIR2]: https://www.iso.org/sites/directives/current/part2/index.xhtml
+[ISODIR2] - ISO/IEC Directives Part 2
+
+[ISO29100]: https://www.iso.org/standard/45123.html
+[ISO29100] - Information technology - Security techniques - Privacy framework
+
+[RFC6749]: https://tools.ietf.org/html/rfc6749
+[RFC6749] - The OAuth 2.0 Authorization Framework
+
+[RFC6750]: https://tools.ietf.org/html/rfc6750
+[RFC6750] - The OAuth 2.0 Authorization Framework: Bearer Token Usage
+
+[RFC7636]: https://tools.ietf.org/html/rfc7636
+[RFC7636] - Proof Key for Code Exchange by OAuth Public Clients
+
+[RFC6819]: https://tools.ietf.org/html/rfc6819
+[RFC6819] - OAuth 2.0 Threat Model and Security Considerations
+
+[RFC7519]: https://tools.ietf.org/html/rfc7519
+[RFC7519] - JSON Web Token (JWT)
+
+[RFC7591]: https://tools.ietf.org/html/rfc7591
+[RFC7591] - OAuth 2.0 Dynamic Client Registration Protocol
+
+[RFC7592]: https://tools.ietf.org/html/rfc7592
+[RFC7592] - OAuth 2.0 Dynamic Client Registration Management Protocol
+
+[BCP195]: https://tools.ietf.org/html/bcp195
+[BCP195] - Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)
+
+[OIDC]: https://openid.net/specs/openid-connect-core-1_0.html
+[OIDC] - OpenID Connect Core 1.0 incorporating errata set 1
+
+[FAPI-CIBA]: https://bitbucket.org/openid/fapi/src/master/Financial_API_WD_CIBA.md
+[FAPI-CIBA] - Financial-grade API: Client Initiated Backchannel Authentication Profile
+
+[OIDD]: https://openid.net/specs/openid-connect-discovery-1_0.html
+[OIDD] - OpenID Connect Discovery 1.0 incorporating errata set 1
+
+[OIDR]: https://openid.net/specs/openid-connect-registration-1_0.html
+[OIDR] - OpenID Connect Registration 1.0 incorporating errata set 1
+
+[RFC8705]: https://tools.ietf.org/html/rfc8705
+[RFC8705] - OAuth 2.0 Mutual TLS Client Authentication and Certificate Bound Access Tokens
+
+[JARM]: https://bitbucket.org/openid/fapi/src/master/Financial_API_JWT_Secured_Authorization_Response_Mode.md
+[JARM] - Financial-grade API: JWT Secured Authorization Response Mode for OAuth 2.0 (JARM)
+
+[PAR]: https://tools.ietf.org/html/draft-ietf-oauth-par
+[PAR] - OAuth 2.0 Pushed Authorization Requests
+
+[JAR]: https://tools.ietf.org/html/draft-ietf-oauth-jwsreq
+[JAR] - OAuth 2.0 JWT Secured Authorization Request
+
+[FAPI-1-Baseline]: https://openid.net/specs/openid-financial-api-part-1-1_0.html
+[FAPI-1-Baseline] - Financial-grade API Security Profile 1.0 - Part 1: Baseline
+
+[FAPI-1-Advanced]: https://openid.net/specs/openid-financial-api-part-2-1_0.html
+[FAPI-1-Advanced] - Financial-grade API Security Profile 1.0 - Part 2: Advanced
+
+[FAPI-2-Baseline]: https://bitbucket.org/openid/fapi/src/master/FAPI_2_0_Baseline_Profile.md
+[FAPI-2-Baseline] - Financial-grade API Security Profile 2.0 - Part 1: Baseline
+
+[LIWP]: https://bitbucket.org/openid/fapi/src/master/Financial_API_Lodging_Intent.md
+[LIWP] - OIDF FAPI WG Lodging Intent Working Paper
+
+[OBB-FAPI]: https://openbanking-brasil.github.io/specs-seguranca/open-banking-brasil-financial-api-1_ID1.html
+[OBB-FAPI] - Open Banking Brasil Financial-grade API Security Profile 1.0
+
+[OBB-FAPI-DCR]: https://openbanking-brasil.github.io/specs-seguranca/open-banking-brasil-dynamic-client-registration-1_ID1.html
+[OBB-FAPI-DCR] - Open Banking Brasil Financial-grade API Dynamic Client Registration Profile 1.0
+
+[OBB-Cert-Standards]: https://openbanking-brasil.github.io/specs-seguranca/open-banking-brasil-certificate-standards-1_ID1.html
+[OBB-Cert-Standards] - Open Banking Brasil x.509 Certificate Standards
+
+## Glossário  {#terms}
+
+Sigla | Descrição | Informação
+-----|------|------
+API	| Application Programming Interface - Interface de programação de aplicativo | Uma interface de programação de aplicativo é um conjunto de rotinas, protocolos e ferramentas para construir aplicativos de software. Uma API especifica como os componentes de software devem interagir
+AC | Autoridade Certificadora | 
+AES	| Advanced Encryption Standard | Algoritmo de criptografia de bloco simétrico com uma chave de criptografia de 256 bits
+AR | Autoridade de Registro	| 
+ASPSP | Account Servicing Payment Service Provide - Instituições Transmissoras - Provedor de serviços de pagamento de manutenção de contas | Um ASPSP é qualquer instituição financeira que oferece uma conta de pagamento com acesso online. Os ASPSPs devem fornecer acesso para permitir que terceiros (TPP) registrados acessem as informações da conta através de APIs
+Autenticação mútua |  | Chamamos de autenticação mútua quando ambos cliente e servidor apresentam certificados para serem validados pelo par.
+Back-End | | Aplicação ou código que da inteligência de negócio as ações solicitadas via API , código que efetivamente realiza a função desejada
+CIBA | Client Initiated Backchannel Authentication | A autenticação de backchannel iniciada pelo cliente (CIBA) é um dos padrões mais recentes da OpenID Foundation. são categorizados como "fluxo desacoplado", Ele permite novas maneiras de obter o consentimento do usuário final
+Claims | | São escopos/declarações usadas em uma API durante a autenticação para autorizar o acesso aos detalhes de um usuário, como nome e imagem por exemplo. Cada escopo retorna um conjunto de atributos do usuário, que são chamados de declarações.
+CSR	| Certificate Signing Request | Contém informação que irá ser incluída no seu certificado como o nome da empresa/organização, common name (domínio), localidade e país. Também contém a chave pública (public key) que será incluída no seu certificado. Normalmente é também criada uma chave privada (private key) ao mesmo tempo que é criado o CSR
+CSRF | Cross Site Request Forgery |
+DCR | Dynamic Client Registration |
+ECDHE | Elliptic-curve Diffie–Hellman | É um protocolo de contrato chave que permite que duas partes, cada uma com um par de chaves público-privado de curva elíptica, estabeleçam um segredo compartilhado em um canal inseguro
+ECDSA | Elliptic Curve Digital Signature Algorithm | É um algoritmo de método de assinatura digital de documentos utilizando criptografia baseada em curvas elípticas.
+EIOBB | Estrutura Inicial do Open Banking Brasil |
+End User | | Identificação de usuário final que possui as informações que se deseja acessar
+FAPI | Financial-grade API | Especificação técnica de API e define requisitos técnicos adicionais para o setor financeiro
+Header | | É o cabeçalho de uma solicitação ou resposta que transmite contexto e metadados adicionais sobre a solicitação ou resposta. Por exemplo, em uma mensagem de solicitação podem ser usados para fornecer credenciais de autenticação.
+HTTP | Hyper Text Transfer Protocol |
+ICP-Brasil | Infraestrutura de Chaves Públicas Brasileira | Na definição oficial, “uma cadeia hierárquica de confiança que viabiliza a emissão de certificados digitais para identificação virtual do cidadão
+Json | JavaScript Object Notation | Json é um modelo para armazenamento e transmissão de informações no formato texto.
+JWS | JSON Web Signature | É uma forma de garantir a integridade das informações em um formato altamente serializado
+JWT | JSON Web Token | É uma técnica definida na RFC 7519 para autenticação remota entre duas partes. Ele é uma das formas mais utilizadas para autenticar usuários em APIs RESTful.
+MAC | Código de Autenticação de Mensagem | Permite que as declarações sejam assinadas digitalmente ou protegidas por integridade utilizando JWS
+MFA | Multi-Factor Authentication |
+mTLS | Mutual Transport Layer Security |
+Oauth | | O OAuth é um protocolo de autorização para API's web voltado a permitir que aplicações client acessem um recurso protegido em nome de um usuário.
+OIDC | OpenID Connect | OpenID Connect é um protocolo de identidade simples com padrão aberto
+OIDF | OpenID Foundation | 
+Payload | | O Payload é a Carga Útil do token JWT. É aqui que você coloca informações como a quem o token pertence, qual a expiração dele, quando ele foi criado, entre outras coisas
+PISP | Payment Initiation Service Provider | 
+PKCE | Proof Key for Code Exchange | Chave de prova para troca de código por clientes públicos Oauth
+REST | Representational State Transfer | 
+SHA256 | Secure Hash Algorithm | É um conjunto de funções criptográficas de hash
+SS | Software Statement |
+SSA | Software Statement Assertion | SSA é um JSON Web Token (JWT) que contém metadados sobre uma instância de aplicativo client desenvolvida por um TPP. O JWT é emitido e assinado pelo OpenBanking Directory.
+TLS	| Transport Layer Security | 
+TPP	| Third Party Provider - Instituições Provedoras - Provedores terceirizados | As instituições provedoras são organizações que usam APIs desenvolvidas pelos ASPSP para acessar contas de clientes, a fim de fornecer serviços de informações de contas
 
 ## Principais Padrões de Segurança  {#Padroes}
 
@@ -1818,125 +1939,3 @@ Tanto transmissoras quanto receptoras devem seguir as orientações da Apple e d
 
 No caso de um usuário não ter o aplicativo instalado em seu dispositivo, ou se ele tiver um sistema operacional mais antigo ou sem suporte (por exemplo, Windows Mobile), esses métodos permitirão que o usuário seja redirecionado para uma página web mobile.
 
-## Referências normativas  {#Normative}
-
-Os seguintes documentos referenciados são indispensáveis para a adoção das especificações deste documento. Para referências datadas, apenas a edição citada se aplica. Para referências não datadas, deve-se aplicar a última edição do documento referenciado (incluindo quaisquer emendas).
-
-[ISODIR2]: https://www.iso.org/sites/directives/current/part2/index.xhtml
-[ISODIR2] - ISO/IEC Directives Part 2
-
-[ISO29100]: https://www.iso.org/standard/45123.html
-[ISO29100] - Information technology - Security techniques - Privacy framework
-
-[RFC6749]: https://tools.ietf.org/html/rfc6749
-[RFC6749] - The OAuth 2.0 Authorization Framework
-
-[RFC6750]: https://tools.ietf.org/html/rfc6750
-[RFC6750] - The OAuth 2.0 Authorization Framework: Bearer Token Usage
-
-[RFC7636]: https://tools.ietf.org/html/rfc7636
-[RFC7636] - Proof Key for Code Exchange by OAuth Public Clients
-
-[RFC6819]: https://tools.ietf.org/html/rfc6819
-[RFC6819] - OAuth 2.0 Threat Model and Security Considerations
-
-[RFC7519]: https://tools.ietf.org/html/rfc7519
-[RFC7519] - JSON Web Token (JWT)
-
-[RFC7591]: https://tools.ietf.org/html/rfc7591
-[RFC7591] - OAuth 2.0 Dynamic Client Registration Protocol
-
-[RFC7592]: https://tools.ietf.org/html/rfc7592
-[RFC7592] - OAuth 2.0 Dynamic Client Registration Management Protocol
-
-[BCP195]: https://tools.ietf.org/html/bcp195
-[BCP195] - Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)
-
-[OIDC]: https://openid.net/specs/openid-connect-core-1_0.html
-[OIDC] - OpenID Connect Core 1.0 incorporating errata set 1
-
-[FAPI-CIBA]: https://bitbucket.org/openid/fapi/src/master/Financial_API_WD_CIBA.md
-[FAPI-CIBA] - Financial-grade API: Client Initiated Backchannel Authentication Profile
-
-[OIDD]: https://openid.net/specs/openid-connect-discovery-1_0.html
-[OIDD] - OpenID Connect Discovery 1.0 incorporating errata set 1
-
-[OIDR]: https://openid.net/specs/openid-connect-registration-1_0.html
-[OIDR] - OpenID Connect Registration 1.0 incorporating errata set 1
-
-[RFC8705]: https://tools.ietf.org/html/rfc8705
-[RFC8705] - OAuth 2.0 Mutual TLS Client Authentication and Certificate Bound Access Tokens
-
-[JARM]: https://bitbucket.org/openid/fapi/src/master/Financial_API_JWT_Secured_Authorization_Response_Mode.md
-[JARM] - Financial-grade API: JWT Secured Authorization Response Mode for OAuth 2.0 (JARM)
-
-[PAR]: https://tools.ietf.org/html/draft-ietf-oauth-par
-[PAR] - OAuth 2.0 Pushed Authorization Requests
-
-[JAR]: https://tools.ietf.org/html/draft-ietf-oauth-jwsreq
-[JAR] - OAuth 2.0 JWT Secured Authorization Request
-
-[FAPI-1-Baseline]: https://openid.net/specs/openid-financial-api-part-1-1_0.html
-[FAPI-1-Baseline] - Financial-grade API Security Profile 1.0 - Part 1: Baseline
-
-[FAPI-1-Advanced]: https://openid.net/specs/openid-financial-api-part-2-1_0.html
-[FAPI-1-Advanced] - Financial-grade API Security Profile 1.0 - Part 2: Advanced
-
-[FAPI-2-Baseline]: https://bitbucket.org/openid/fapi/src/master/FAPI_2_0_Baseline_Profile.md
-[FAPI-2-Baseline] - Financial-grade API Security Profile 2.0 - Part 1: Baseline
-
-[LIWP]: https://bitbucket.org/openid/fapi/src/master/Financial_API_Lodging_Intent.md
-[LIWP] - OIDF FAPI WG Lodging Intent Working Paper
-
-[OBB-FAPI]: https://openbanking-brasil.github.io/specs-seguranca/open-banking-brasil-financial-api-1_ID1.html
-[OBB-FAPI] - Open Banking Brasil Financial-grade API Security Profile 1.0
-
-[OBB-FAPI-DCR]: https://openbanking-brasil.github.io/specs-seguranca/open-banking-brasil-dynamic-client-registration-1_ID1.html
-[OBB-FAPI-DCR] - Open Banking Brasil Financial-grade API Dynamic Client Registration Profile 1.0
-
-[OBB-Cert-Standards]: https://openbanking-brasil.github.io/specs-seguranca/open-banking-brasil-certificate-standards-1_ID1.html
-[OBB-Cert-Standards] - Open Banking Brasil x.509 Certificate Standards
-
-
-## Glossário  {#terms}
-
-Sigla | Descrição | Informação
------|------|------
-API	| Application Programming Interface - Interface de programação de aplicativo | Uma interface de programação de aplicativo é um conjunto de rotinas, protocolos e ferramentas para construir aplicativos de software. Uma API especifica como os componentes de software devem interagir
-AC | Autoridade Certificadora | 
-AES	| Advanced Encryption Standard | Algoritmo de criptografia de bloco simétrico com uma chave de criptografia de 256 bits"
-AR | Autoridade de Registro	| 
-ASPSP | Account Servicing Payment Service Provide - Instituições Transmissoras - Provedor de serviços de pagamento de manutenção de contas | Um ASPSP é qualquer instituição financeira que oferece uma conta de pagamento com acesso online. Os ASPSPs devem fornecer acesso para permitir que terceiros (TPP) registrados acessem as informações da conta através de APIs
-Autenticação mútua |  | Chamamos de autenticação mútua quando ambos cliente e servidor apresentam certificados para serem validados pelo par.
-Back-End | | Aplicação ou código que da inteligência de negócio as ações solicitadas via API , código que efetivamente realiza a função desejada
-CIBA | Client Initiated Backchannel Authentication | A autenticação de backchannel iniciada pelo cliente (CIBA) é um dos padrões mais recentes da OpenID Foundation. são categorizados como "fluxo desacoplado", Ele permite novas maneiras de obter o consentimento do usuário final
-Claims | | São escopos/declarações usadas em uma API durante a autenticação para autorizar o acesso aos detalhes de um usuário, como nome e imagem por exemplo. Cada escopo retorna um conjunto de atributos do usuário, que são chamados de declarações.
-CSR	| Certificate Signing Request | Contém informação que irá ser incluída no seu certificado como o nome da empresa/organização, common name (domínio), localidade e país. Também contém a chave pública (public key) que será incluída no seu certificado. Normalmente é também criada uma chave privada (private key) ao mesmo tempo que é criado o CSR"
-CSRF | Cross Site Request Forgery |
-DCR | Dynamic Client Registration |
-ECDHE | Elliptic-curve Diffie–Hellman | É um protocolo de contrato chave que permite que duas partes, cada uma com um par de chaves público-privado de curva elíptica, estabeleçam um segredo compartilhado em um canal inseguro
-ECDSA | Elliptic Curve Digital Signature Algorithm | É um algoritmo de método de assinatura digital de documentos utilizando criptografia baseada em curvas elípticas.
-EIOBB | Estrutura Inicial do Open Banking Brasil |
-End User | | Identificação de usuário final que possui as informações que se deseja acessar
-FAPI | Financial-grade API | Especificação técnica de API e define requisitos técnicos adicionais para o setor financeiro
-Header | | É o cabeçalho de uma solicitação ou resposta que transmite contexto e metadados adicionais sobre a solicitação ou resposta. Por exemplo, em uma mensagem de solicitação podem ser usados para fornecer credenciais de autenticação.
-HTTP | Hyper Text Transfer Protocol |
-ICP-Brasil | Infraestrutura de Chaves Públicas Brasileira | Na definição oficial, “uma cadeia hierárquica de confiança que viabiliza a emissão de certificados digitais para identificação virtual do cidadão
-Json | JavaScript Object Notation | Json é um modelo para armazenamento e transmissão de informações no formato texto.
-JWS | JSON Web Signature | É uma forma de garantir a integridade das informações em um formato altamente serializado
-JWT | JSON Web Token | É uma técnica definida na RFC 7519 para autenticação remota entre duas partes. Ele é uma das formas mais utilizadas para autenticar usuários em APIs RESTful.
-MAC | Código de Autenticação de Mensagem | Permite que as declarações sejam assinadas digitalmente ou protegidas por integridade utilizando JWS
-MFA | Multi-Factor Authentication |
-mTLS | Mutual Transport Layer Security |
-Oauth | | O OAuth é um protocolo de autorização para API's web voltado a permitir que aplicações client acessem um recurso protegido em nome de um usuário.
-OIDC | OpenID Connect | OpenID Connect é um protocolo de identidade simples com padrão aberto
-OIDF | OpenID Foundation | 
-Payload | | O Payload é a Carga Útil do token JWT. É aqui que você coloca informações como a quem o token pertence, qual a expiração dele, quando ele foi criado, entre outras coisas
-PISP | Payment Initiation Service Provider | 
-PKCE | Proof Key for Code Exchange | Chave de prova para troca de código por clientes públicos Oauth
-REST | Representational State Transfer | 
-SHA256 | Secure Hash Algorithm | É um conjunto de funções criptográficas de hash
-SS | Software Statement |
-SSA | Software Statement Assertion | SSA é um JSON Web Token (JWT) que contém metadados sobre uma instância de aplicativo client desenvolvida por um TPP. O JWT é emitido e assinado pelo OpenBanking Directory.
-TLS	| Transport Layer Security | "
-TPP	| Third Party Provider - Instituições Provedoras - Provedores terceirizados | As instituições provedoras são organizações que usam APIs desenvolvidas pelos ASPSP para acessar contas de clientes, a fim de fornecer serviços de informações de contas"

--- a/all-documents.md
+++ b/all-documents.md
@@ -203,9 +203,9 @@ Os seguintes documentos referenciados são indispensáveis para a adoção das e
 Sigla | Descrição | Informação
 -----|------|------
 API	| Application Programming Interface - Interface de programação de aplicativo | Uma interface de programação de aplicativo é um conjunto de rotinas, protocolos e ferramentas para construir aplicativos de software. Uma API especifica como os componentes de software devem interagir
-AC | Autoridade Certificadora | 
+AC | Autoridade Certificadora |
 AES	| Advanced Encryption Standard | Algoritmo de criptografia de bloco simétrico com uma chave de criptografia de 256 bits
-AR | Autoridade de Registro	| 
+AR | Autoridade de Registro	|
 ASPSP | Account Servicing Payment Service Provide - Instituições Transmissoras - Provedor de serviços de pagamento de manutenção de contas | Um ASPSP é qualquer instituição financeira que oferece uma conta de pagamento com acesso online. Os ASPSPs devem fornecer acesso para permitir que terceiros (TPP) registrados acessem as informações da conta através de APIs
 Autenticação mútua |  | Chamamos de autenticação mútua quando ambos cliente e servidor apresentam certificados para serem validados pelo par.
 Back-End | | Aplicação ou código que da inteligência de negócio as ações solicitadas via API , código que efetivamente realiza a função desejada
@@ -230,15 +230,15 @@ MFA | Multi-Factor Authentication |
 mTLS | Mutual Transport Layer Security |
 Oauth | | O OAuth é um protocolo de autorização para API's web voltado a permitir que aplicações client acessem um recurso protegido em nome de um usuário.
 OIDC | OpenID Connect | OpenID Connect é um protocolo de identidade simples com padrão aberto
-OIDF | OpenID Foundation | 
+OIDF | OpenID Foundation |
 Payload | | O Payload é a Carga Útil do token JWT. É aqui que você coloca informações como a quem o token pertence, qual a expiração dele, quando ele foi criado, entre outras coisas
-PISP | Payment Initiation Service Provider | 
+PISP | Payment Initiation Service Provider |
 PKCE | Proof Key for Code Exchange | Chave de prova para troca de código por clientes públicos Oauth
-REST | Representational State Transfer | 
+REST | Representational State Transfer |
 SHA256 | Secure Hash Algorithm | É um conjunto de funções criptográficas de hash
 SS | Software Statement |
 SSA | Software Statement Assertion | SSA é um JSON Web Token (JWT) que contém metadados sobre uma instância de aplicativo client desenvolvida por um TPP. O JWT é emitido e assinado pelo OpenBanking Directory.
-TLS	| Transport Layer Security | 
+TLS	| Transport Layer Security |
 TPP	| Third Party Provider - Instituições Provedoras - Provedores terceirizados | As instituições provedoras são organizações que usam APIs desenvolvidas pelos ASPSP para acessar contas de clientes, a fim de fornecer serviços de informações de contas
 
 ## Principais Padrões de Segurança  {#Padroes}
@@ -335,8 +335,8 @@ Além disso, ele deve:
 1. deve suportar Request Objects JWE assinados e criptografados passados por valor ou deve exigir requisições do tipo "pushed authorization requests" [PAR]
 2. deve publicar metadados de descoberta (incluindo a do endpoint de autorização) por meio do documento de metadado especificado em [OIDD] e [RFC8414] (".well-known")
 3. deve suportar os parâmetros `claims` como definido no item 5.5 do [OpenID Connect Core][OIDC]
-4. deve suportar o atributo `claim` padrão oidc "cpf" conforme definido no item 5.2.2.2 deste documento
-5. deve suportar o atributo `claim` padrão oidc "cnpj" conforme definido no item 5.2.2.3 deste documento
+4. deve suportar o atributo `claim` padrão oidc "cpf" conforme definido no item 5.2.2.2 deste documento, se a instituição oferece acesso a recursos de pessoas físicas.
+5. deve suportar o atributo `claim` padrão oidc "cnpj" conforme definido no item 5.2.2.3 deste documento, se a instituição oferece acesso a recursos de pessoas jurídicas.
 6. deve suportar o atributo `acr` "urn:brasil:openbanking:loa2" como definido no item 5.2.2.4 deste documento
 7. deveria suportar o atributo `acr` "urn:brasil:openbanking:loa3" como definido no item 5.2.2.4 deste documento
 8. deve implementar o endpoint "userinfo" como definido no item 5.3 do [OpenID Connect Core][OIDC]
@@ -1861,13 +1861,13 @@ organizationalUnitName = <Código de Participante>
 UID = <Software Statement ID emitido pelo diretório>
 commonName = <FQDN|Wildcard>
 
-[ req_cert_extensions ] 
+[ req_cert_extensions ]
 basicConstraints = CA:FALSE
 subjectAltName = @alt_name
 keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth
 
-[ alt_name ] 
+[ alt_name ]
 DNS = <FQDN|Wildcard>
 ```
 
@@ -1892,12 +1892,12 @@ organizationName = ICP-Brasil
 2.organizationalUnitName = <Tipo de validação>
 commonName = <Razão Social>
 
-[ req_cert_extensions ] 
+[ req_cert_extensions ]
 basicConstraints = CA:FALSE
 subjectAltName = @alt_name
 keyUsage = critical,digitalSignature,nonRepudiation
 
-[ alt_name ] 
+[ alt_name ]
 otherName.0 = 2.16.76.1.3.2;UTF8:<Nome da pessoa responsável pela entidade>#CNPJ
 otherName.1 = 2.16.76.1.3.3;UTF8<CNPJ>
 otherName.2 = 2.16.76.1.3.4;UTF8:<CPF/PIS/RF da Pessoa responsável>
@@ -1938,4 +1938,3 @@ Tanto transmissoras quanto receptoras devem seguir as orientações da Apple e d
 * Android: https://developer.android.com/training/app-links/index.html (cobre 65% de todos os usuários do Android, que estão no Android 6.0 ou posterior).
 
 No caso de um usuário não ter o aplicativo instalado em seu dispositivo, ou se ele tiver um sistema operacional mais antigo ou sem suporte (por exemplo, Windows Mobile), esses métodos permitirão que o usuário seja redirecionado para uma página web mobile.
-

--- a/all-documents.md
+++ b/all-documents.md
@@ -203,9 +203,9 @@ Os seguintes documentos referenciados são indispensáveis para a adoção das e
 Sigla | Descrição | Informação
 -----|------|------
 API	| Application Programming Interface - Interface de programação de aplicativo | Uma interface de programação de aplicativo é um conjunto de rotinas, protocolos e ferramentas para construir aplicativos de software. Uma API especifica como os componentes de software devem interagir
-AC | Autoridade Certificadora |
+AC | Autoridade Certificadora | 
 AES	| Advanced Encryption Standard | Algoritmo de criptografia de bloco simétrico com uma chave de criptografia de 256 bits
-AR | Autoridade de Registro	|
+AR | Autoridade de Registro	| 
 ASPSP | Account Servicing Payment Service Provide - Instituições Transmissoras - Provedor de serviços de pagamento de manutenção de contas | Um ASPSP é qualquer instituição financeira que oferece uma conta de pagamento com acesso online. Os ASPSPs devem fornecer acesso para permitir que terceiros (TPP) registrados acessem as informações da conta através de APIs
 Autenticação mútua |  | Chamamos de autenticação mútua quando ambos cliente e servidor apresentam certificados para serem validados pelo par.
 Back-End | | Aplicação ou código que da inteligência de negócio as ações solicitadas via API , código que efetivamente realiza a função desejada
@@ -230,15 +230,15 @@ MFA | Multi-Factor Authentication |
 mTLS | Mutual Transport Layer Security |
 Oauth | | O OAuth é um protocolo de autorização para API's web voltado a permitir que aplicações client acessem um recurso protegido em nome de um usuário.
 OIDC | OpenID Connect | OpenID Connect é um protocolo de identidade simples com padrão aberto
-OIDF | OpenID Foundation |
+OIDF | OpenID Foundation | 
 Payload | | O Payload é a Carga Útil do token JWT. É aqui que você coloca informações como a quem o token pertence, qual a expiração dele, quando ele foi criado, entre outras coisas
-PISP | Payment Initiation Service Provider |
+PISP | Payment Initiation Service Provider | 
 PKCE | Proof Key for Code Exchange | Chave de prova para troca de código por clientes públicos Oauth
-REST | Representational State Transfer |
+REST | Representational State Transfer | 
 SHA256 | Secure Hash Algorithm | É um conjunto de funções criptográficas de hash
 SS | Software Statement |
 SSA | Software Statement Assertion | SSA é um JSON Web Token (JWT) que contém metadados sobre uma instância de aplicativo client desenvolvida por um TPP. O JWT é emitido e assinado pelo OpenBanking Directory.
-TLS	| Transport Layer Security |
+TLS	| Transport Layer Security | 
 TPP	| Third Party Provider - Instituições Provedoras - Provedores terceirizados | As instituições provedoras são organizações que usam APIs desenvolvidas pelos ASPSP para acessar contas de clientes, a fim de fornecer serviços de informações de contas
 
 ## Principais Padrões de Segurança  {#Padroes}
@@ -335,8 +335,8 @@ Além disso, ele deve:
 1. deve suportar Request Objects JWE assinados e criptografados passados por valor ou deve exigir requisições do tipo "pushed authorization requests" [PAR]
 2. deve publicar metadados de descoberta (incluindo a do endpoint de autorização) por meio do documento de metadado especificado em [OIDD] e [RFC8414] (".well-known")
 3. deve suportar os parâmetros `claims` como definido no item 5.5 do [OpenID Connect Core][OIDC]
-4. deve suportar o atributo `claim` padrão oidc "cpf" conforme definido no item 5.2.2.2 deste documento, se a instituição oferece acesso a recursos de pessoas físicas.
-5. deve suportar o atributo `claim` padrão oidc "cnpj" conforme definido no item 5.2.2.3 deste documento, se a instituição oferece acesso a recursos de pessoas jurídicas.
+4. deve suportar o atributo `claim` padrão oidc "cpf" conforme definido no item 5.2.2.2 deste documento
+5. deve suportar o atributo `claim` padrão oidc "cnpj" conforme definido no item 5.2.2.3 deste documento
 6. deve suportar o atributo `acr` "urn:brasil:openbanking:loa2" como definido no item 5.2.2.4 deste documento
 7. deveria suportar o atributo `acr` "urn:brasil:openbanking:loa3" como definido no item 5.2.2.4 deste documento
 8. deve implementar o endpoint "userinfo" como definido no item 5.3 do [OpenID Connect Core][OIDC]
@@ -1861,13 +1861,13 @@ organizationalUnitName = <Código de Participante>
 UID = <Software Statement ID emitido pelo diretório>
 commonName = <FQDN|Wildcard>
 
-[ req_cert_extensions ]
+[ req_cert_extensions ] 
 basicConstraints = CA:FALSE
 subjectAltName = @alt_name
 keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth
 
-[ alt_name ]
+[ alt_name ] 
 DNS = <FQDN|Wildcard>
 ```
 
@@ -1892,12 +1892,12 @@ organizationName = ICP-Brasil
 2.organizationalUnitName = <Tipo de validação>
 commonName = <Razão Social>
 
-[ req_cert_extensions ]
+[ req_cert_extensions ] 
 basicConstraints = CA:FALSE
 subjectAltName = @alt_name
 keyUsage = critical,digitalSignature,nonRepudiation
 
-[ alt_name ]
+[ alt_name ] 
 otherName.0 = 2.16.76.1.3.2;UTF8:<Nome da pessoa responsável pela entidade>#CNPJ
 otherName.1 = 2.16.76.1.3.3;UTF8<CNPJ>
 otherName.2 = 2.16.76.1.3.4;UTF8:<CPF/PIS/RF da Pessoa responsável>
@@ -1938,3 +1938,4 @@ Tanto transmissoras quanto receptoras devem seguir as orientações da Apple e d
 * Android: https://developer.android.com/training/app-links/index.html (cobre 65% de todos os usuários do Android, que estão no Android 6.0 ou posterior).
 
 No caso de um usuário não ter o aplicativo instalado em seu dispositivo, ou se ele tiver um sistema operacional mais antigo ou sem suporte (por exemplo, Windows Mobile), esses métodos permitirão que o usuário seja redirecionado para uma página web mobile.
+

--- a/all-documents.md
+++ b/all-documents.md
@@ -5,7 +5,7 @@
 
 ## Introdução   {#Introducao}
 
-Esta seção tem como finalidade auxiliar na auto avaliação aos cumprimentos dos requisitos de segurança da informação relacionados a autorização e autenticação de APIs e End-Users, emissão de certificados digitais e requisitos para o onboarding no Diretório de participantes para as Instituições participantes do Open Banking.
+Esta seção tem como finalidade auxiliar na auto avaliação aos cumprimentos dos requisitos de segurança da informação relacionados a autorização e autenticação de APIs e End-Users, emissão de certificados digitais e requisitos para o onboarding no Diretório de Participantes para as Instituições participantes do Open Banking.
 
 As instituições participantes do Open Banking possuem a obrigação de acompanhar a edição e a revogação de eventuais normas com impacto no tema de forma a estar permanentemente em dia com as determinações legais. Compõem, de forma não exaustiva, o rol de atos normativos cuja observância é essencial pelas instituições participantes do Open Banking:
 
@@ -386,7 +386,7 @@ Este profile é aplicável a todos os participantes do Open Banking no Brasil.
 
 ### Diretório de Participantes  {#Intro}
 
-O ecossistema Open Banking Brasil apoia-se em um provedor de confiança ou _diretório de participantes_ como a fonte mais valiosa de informações sobre participantes credenciados e softwares que estão autorizados a participar do ecossistema Open Banking Brasil.
+O ecossistema Open Banking Brasil apoia-se em um provedor de confiança ou _Diretório de Participantes_ como a fonte mais valiosa de informações sobre participantes credenciados e softwares que estão autorizados a participar do ecossistema Open Banking Brasil.
 
 Os serviços do Diretório incluem:
 
@@ -1606,7 +1606,7 @@ Este documento especifica os tipos de certificados necessários para:
 * Autenticar mutuamente (MTLS - Mutual TLS) as aplicações dos participantes;
 * Assinatura de Mensagens (JWS - JSON Web Signature) de aplicações para garantir a autenticidade e não repúdio de mensagens entre os participantes;
 * Apresentar um canal seguro e confiável para clientes do Open Banking Brasil;
-* Autenticar participantes no Diretório de participantes do Open Banking Brasil.
+* Autenticar participantes no Diretório de Participantes do Open Banking Brasil.
 
 ### Introdução {#Introducao}
 
@@ -1902,16 +1902,16 @@ Os seguintes documentos referenciados são indispensáveis para a adoção das e
 
 Sigla | Descrição | Informação
 -----|------|------
-"API	| Application Programming Interface - Interface de programação de aplicativo | Uma interface de programação de aplicativo é um conjunto de rotinas, protocolos e ferramentas para construir aplicativos de software. Uma API especifica como os componentes de software devem interagir."
+API	| Application Programming Interface - Interface de programação de aplicativo | Uma interface de programação de aplicativo é um conjunto de rotinas, protocolos e ferramentas para construir aplicativos de software. Uma API especifica como os componentes de software devem interagir
 AC | Autoridade Certificadora | 
-"AES	| Advanced Encryption Standard | Algoritmo de criptografia de bloco simétrico com uma chave de criptografia de 256 bits"
-"AR | Autoridade de Registro	| "
+AES	| Advanced Encryption Standard | Algoritmo de criptografia de bloco simétrico com uma chave de criptografia de 256 bits"
+AR | Autoridade de Registro	| 
 ASPSP | Account Servicing Payment Service Provide - Instituições Transmissoras - Provedor de serviços de pagamento de manutenção de contas | Um ASPSP é qualquer instituição financeira que oferece uma conta de pagamento com acesso online. Os ASPSPs devem fornecer acesso para permitir que terceiros (TPP) registrados acessem as informações da conta através de APIs
 Autenticação mútua |  | Chamamos de autenticação mútua quando ambos cliente e servidor apresentam certificados para serem validados pelo par.
 Back-End | | Aplicação ou código que da inteligência de negócio as ações solicitadas via API , código que efetivamente realiza a função desejada
 CIBA | Client Initiated Backchannel Authentication | A autenticação de backchannel iniciada pelo cliente (CIBA) é um dos padrões mais recentes da OpenID Foundation. são categorizados como "fluxo desacoplado", Ele permite novas maneiras de obter o consentimento do usuário final
 Claims | | São escopos/declarações usadas em uma API durante a autenticação para autorizar o acesso aos detalhes de um usuário, como nome e imagem por exemplo. Cada escopo retorna um conjunto de atributos do usuário, que são chamados de declarações.
-"CSR	| Certificate Signing Request | Contém informação que irá ser incluída no seu certificado como o nome da empresa/organização, common name (domínio), localidade e país. Também contém a chave pública (public key) que será incluída no seu certificado. Normalmente é também criada uma chave privada (private key) ao mesmo tempo que é criado o CSR"
+CSR	| Certificate Signing Request | Contém informação que irá ser incluída no seu certificado como o nome da empresa/organização, common name (domínio), localidade e país. Também contém a chave pública (public key) que será incluída no seu certificado. Normalmente é também criada uma chave privada (private key) ao mesmo tempo que é criado o CSR"
 CSRF | Cross Site Request Forgery |
 DCR | Dynamic Client Registration |
 ECDHE | Elliptic-curve Diffie–Hellman | É um protocolo de contrato chave que permite que duas partes, cada uma com um par de chaves público-privado de curva elíptica, estabeleçam um segredo compartilhado em um canal inseguro

--- a/open-banking-brasil-financial-api-1_ID1-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID1-ptbr.md
@@ -212,7 +212,7 @@ Além disso, ele deve:
 1. deve suportar Request Objects JWE assinados e criptografados passados por valor ou deve exigir requisições do tipo "pushed authorization requests" [PAR]
 2. deve publicar metadados de descoberta (incluindo a do endpoint de autorização) por meio do documento de metadado especificado em [OIDD] e [RFC8414] (".well-known")
 3. deve suportar os parâmetros `claims` como definido no item 5.5 do [OpenID Connect Core][OIDC]
-4. deve suportar o atributo `claim` padrão oidc "cpf" conforme definido no item 5.2.2.2 deste documento, se a instituição oferece acesso a recursos de pessoas físicas.
+4. deve suportar o atributo `claim` padrão oidc "cpf" conforme definido no item 5.2.2.2 deste documento.
 5. deve suportar o atributo `claim` padrão oidc "cnpj" conforme definido no item 5.2.2.3 deste documento, se a instituição oferece acesso a recursos de pessoas jurídicas.
 6. deve suportar o atributo `acr` "urn:brasil:openbanking:loa2" como definido no item 5.2.2.4 deste documento
 7. deveria suportar o atributo `acr` "urn:brasil:openbanking:loa3" como definido no item 5.2.2.4 deste documento

--- a/open-banking-brasil-financial-api-1_ID1-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID1-ptbr.md
@@ -212,8 +212,8 @@ Além disso, ele deve:
 1. deve suportar Request Objects JWE assinados e criptografados passados por valor ou deve exigir requisições do tipo "pushed authorization requests" [PAR]
 2. deve publicar metadados de descoberta (incluindo a do endpoint de autorização) por meio do documento de metadado especificado em [OIDD] e [RFC8414] (".well-known")
 3. deve suportar os parâmetros `claims` como definido no item 5.5 do [OpenID Connect Core][OIDC]
-4. deve suportar o atributo `claim` padrão oidc "cpf" conforme definido no item 5.2.2.2 deste documento
-5. deve suportar o atributo `claim` padrão oidc "cnpj" conforme definido no item 5.2.2.3 deste documento
+4. deve suportar o atributo `claim` padrão oidc "cpf" conforme definido no item 5.2.2.2 deste documento, se a instituição oferece acesso a recursos de pessoas físicas.
+5. deve suportar o atributo `claim` padrão oidc "cnpj" conforme definido no item 5.2.2.3 deste documento, se a instituição oferece acesso a recursos de pessoas jurídicas.
 6. deve suportar o atributo `acr` "urn:brasil:openbanking:loa2" como definido no item 5.2.2.4 deste documento
 7. deveria suportar o atributo `acr` "urn:brasil:openbanking:loa3" como definido no item 5.2.2.4 deste documento
 8. deve implementar o endpoint "userinfo" como definido no item 5.3 do [OpenID Connect Core][OIDC]


### PR DESCRIPTION
Corrige issue #112 para indicar opcional atributos que não fazem sentido para instituições que só tratam PF.
Pessoal, mantive a proposta do PR #120 aberto pelo @RalphBragg, mas questiono sobre a opcionalidade da claim CPF, pois entendo que essa não deveria ser opcional.

Fix Bug #112 .  @GislaineAlmeida, @DeiGratia33 and @alex-siqueira would you please check my comment at #120 ? As we always have a person authenticatiing aganst ASPSP system and giving his consent to share data, even when he selected a business account (assuming UX is going to give some option to a user select an especific account), at the end, we always have a CPF that should be related to an account / authentication, right @GislaineAlmeida @alex-siqueira ? If it is true, we have to keep line 4 as it was originally.