### PR TITLE
userinfo TTP User Guide BR, refresh_tokens expiration, LoA3 adjusts and endpoint vs certificates table

### DIFF
--- a/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
+++ b/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
@@ -239,6 +239,7 @@ As seguintes pessoas contribuíram para este documento:
 * José Michael Dias (Grupo Pan)
 * Ralph Bragg (Raidiam)
 * Ediemerson Moreira Alves (Santander)
+* João Rodolfo Vieira (Itaú)
 
 # Informativo {#Informativo}
 

--- a/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
+++ b/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
@@ -229,7 +229,7 @@ De acordo com a seção IV da Resolução Conjunta nº 1 de 4 de maio de 2020, o
 
 Em consonância com o §2º do Art. 10 da Medida Provisória 2.200-2 de 24 de agosto de 2001 e com o disposto no item 3.12 na Instrução Normativa BCB Nº 134, para a comunicação bilateral entre as instituições e parceiros fica autorizado o uso, em comum acordo entre as partes, de uma PKI privada desde que observados os requisitos deste _perfil para os certificados segurança_, o que inclui sua formatação, os algoritmos e os atributos estabelecidos.
 
-Os valores para o preenchimento dos atributos exigidos nessa especificação, mas não aplicáveis ao parceiro, deveriam ser definidos em comum acordo entre a instituição autorizada e o parceiro, o que não isenta da instituição autorizada a responsabilidade pelo preenchimento adequado.
+Os valores para o preenchimento dos atributos exigidos nessa especificação, mas não aplicáveis ao parceiro, deveriam ser definidos em comum acordo entre a instituição autorizada e o parceiro, o que não isenta da instituição autorizada a responsabilidade pelo preenchimento.
 
 # Reconhecimento {#Reconhecimento}
 

--- a/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
+++ b/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
@@ -273,7 +273,7 @@ stateOrProvinceName = <UF>
 localityName = <Cidade>
 organizationalUnitName = <Código de Participante>
 UID = <Software Statement ID emitido pelo diretório>
-commonName = <FQDN>
+commonName = <FQDN|Wildcard>
 
 [ req_cert_extensions ]
 basicConstraints = CA:FALSE
@@ -282,7 +282,7 @@ keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth
 
 [ alt_name ]
-DNS = <FQDN>
+DNS = <FQDN|Wildcard>
 ```
 
 ## Modelo de Configuração de Certificado de Assinatura - OpenSSL {#ModeloConfiguracaoCertificadoAssinaturaOpenSSL}

--- a/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
+++ b/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
@@ -223,6 +223,12 @@ As seguintes autoridades certificadoras realizaram o processo de onboard ao Open
 
 Os certificados para Front-End são utilizados para disponibilizar serviços, em geral páginas Web, com uso de TLS, que são acessados pelo usuário final. Dado a sua finalidade, e para garantir maior interoperabilidade, os certificados devem ser do tipo EV (Extended Validation) e devem ser ser gerados através de uma autoridade certificadora válida, seguindo as regras definidas na RFC 5280 e RFC 2818, em conformidade com os princípios e critérios WebTrust.
 
+### Sobre certificados para troca de informações entre instituições participantes e parceiros
+
+De acordo com a seção IV da Resolução Conjunta nº 1 de 4 de maio de 2020, o  estabelecimento de parcerias bilaterais com instituições não participantes é um arranjo previsto na regulação e que deve observar, no que couber, inclusive os mesmos requisitos de comunicação e de segurança que são aplicáveis para a troca de informações entre as instituições participantes.
+
+Em consonância com o §2º do Art. 10 da Medida Provisória 2.200-2 de 24 de agosto de 2001 e com o disposto no item 3.12 na Instrução Normativa BCB Nº 134, para a comunicação bilateral entre as instituições e parceiros fica autorizado o uso, em comum acordo entre as partes, de uma PKI privada desde que observados os requisitos deste _perfil para os certificados segurança_, o que inclui sua formatação, os algoritmos e os atributos estabelecidos. Os valores para o preenchimento dos atributos exigidos nessa especificação mas não aplicáveis ao parceiro, devem ser definidos em comum acordo entre a instituição participante e o parceiro.
+
 # Reconhecimento {#Reconhecimento}
 
 Agradecemos a todos que estabeleceram as bases para o compartilhamento seguro e seguro de dados por meio da formação do Grupo de Trabalho FAPI da OpenID Foundation, o GT-Segurança do Open Banking Brasil e aos pioneiros que ficarão em seus ombros.
@@ -268,13 +274,13 @@ organizationalUnitName = <Código de Participante>
 UID = <Software Statement ID emitido pelo diretório>
 commonName = <FQDN|Wildcard>
 
-[ req_cert_extensions ] 
+[ req_cert_extensions ]
 basicConstraints = CA:FALSE
 subjectAltName = @alt_name
 keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth
 
-[ alt_name ] 
+[ alt_name ]
 DNS = <FQDN|Wildcard>
 ```
 
@@ -299,12 +305,12 @@ organizationName = ICP-Brasil
 2.organizationalUnitName = <Tipo de validação>
 commonName = <Razão Social>
 
-[ req_cert_extensions ] 
+[ req_cert_extensions ]
 basicConstraints = CA:FALSE
 subjectAltName = @alt_name
 keyUsage = critical,digitalSignature,nonRepudiation
 
-[ alt_name ] 
+[ alt_name ]
 otherName.0 = 2.16.76.1.3.2;UTF8:<Nome da pessoal responsável pela entidade>#CNPJ
 otherName.1 = 2.16.76.1.3.3;UTF8:<CNPJ>
 otherName.2 = 2.16.76.1.3.4;UTF8:<CPF/PIS/RF da Pessoa responsável>

--- a/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
+++ b/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
@@ -223,11 +223,13 @@ As seguintes autoridades certificadoras realizaram o processo de onboard ao Open
 
 Os certificados para Front-End são utilizados para disponibilizar serviços, em geral páginas Web, com uso de TLS, que são acessados pelo usuário final. Dado a sua finalidade, e para garantir maior interoperabilidade, os certificados devem ser do tipo EV (Extended Validation) e devem ser ser gerados através de uma autoridade certificadora válida, seguindo as regras definidas na RFC 5280 e RFC 2818, em conformidade com os princípios e critérios WebTrust.
 
-### Sobre certificados para troca de informações entre instituições participantes e parceiros
+### Sobre certificados para troca de informações entre instituições autorizadas e parceiros
 
-De acordo com a seção IV da Resolução Conjunta nº 1 de 4 de maio de 2020, o  estabelecimento de parcerias bilaterais com instituições não participantes é um arranjo previsto na regulação e que deve observar, no que couber, inclusive os mesmos requisitos de comunicação e de segurança que são aplicáveis para a troca de informações entre as instituições participantes.
+De acordo com a seção IV da Resolução Conjunta nº 1 de 4 de maio de 2020, o  estabelecimento de parcerias bilaterais entre instituições autorizadas e parceiros é um arranjo previsto na regulação e que deve observar, no que couber, inclusive os mesmos padrões e certificados de segurança que são aplicáveis para a troca de informações entre as instituições participantes.
 
-Em consonância com o §2º do Art. 10 da Medida Provisória 2.200-2 de 24 de agosto de 2001 e com o disposto no item 3.12 na Instrução Normativa BCB Nº 134, para a comunicação bilateral entre as instituições e parceiros fica autorizado o uso, em comum acordo entre as partes, de uma PKI privada desde que observados os requisitos deste _perfil para os certificados segurança_, o que inclui sua formatação, os algoritmos e os atributos estabelecidos. Os valores para o preenchimento dos atributos exigidos nessa especificação mas não aplicáveis ao parceiro, devem ser definidos em comum acordo entre a instituição participante e o parceiro.
+Em consonância com o §2º do Art. 10 da Medida Provisória 2.200-2 de 24 de agosto de 2001 e com o disposto no item 3.12 na Instrução Normativa BCB Nº 134, para a comunicação bilateral entre as instituições e parceiros fica autorizado o uso, em comum acordo entre as partes, de uma PKI privada desde que observados os requisitos deste _perfil para os certificados segurança_, o que inclui sua formatação, os algoritmos e os atributos estabelecidos.
+
+Os valores para o preenchimento dos atributos exigidos nessa especificação, mas não aplicáveis ao parceiro, deveriam ser definidos em comum acordo entre a instituição autorizada e o parceiro, o que não isenta da instituição autorizada a responsabilidade pelo preenchimento adequado.
 
 # Reconhecimento {#Reconhecimento}
 
@@ -312,7 +314,10 @@ subjectAltName = @alt_name
 keyUsage = critical,digitalSignature,nonRepudiation
 
 [ alt_name ]
-otherName.0 = 2.16.76.1.3.3;UTF8:<CNPJ>
+otherName.0 = 2.16.76.1.3.2;UTF8:<Nome da pessoal responsável pela entidade>#CNPJ
+otherName.1 = 2.16.76.1.3.3;UTF8:<CNPJ>
+otherName.2 = 2.16.76.1.3.4;UTF8:<CPF/PIS/RF da Pessoa responsável>
+otherName.3 = 2.16.76.1.3.7;UTF8:<Número de INSS>
 ```
 ## Tabela com Endpoints vs Tipo de Certificado e mTLS
 Abaixo apresentamos quais endpoints podem ser publicados utilizando certificado EV como autenticação do consentimento e os endpoints de autenticação de APIs privadas/negócios que devem ser publicadas usando certificado ICP. Você também poderá verificar quais endpoints devem proteger suas conexões utilizando mTLS.
@@ -327,6 +332,7 @@ NA | OIDC | userinfo_endpoint | ICP WEB SSL | Obrigatório
 NA | OIDC | pushed_authorization_request_endpoint |  ICP WEB SSL | Obrigatório
 NA | DCR | registration_endpoint |  ICP WEB SSL | Obrigatório
 NA | OIDC | revocation_endpoint | ICP WEB SSL | Obrigatório
+NA | OIDC | introspection_endpoint (*) | ICP WEB SSL | Obrigatório
 2 | Consentimentos | /consents/* |  ICP WEB SSL | Obrigatório
 2 | Resources | /resources/* | ICP WEB SSL | Obrigatório
 2 | Dados | /customers/* | ICP WEB SSL | Obrigatório
@@ -337,3 +343,5 @@ NA | OIDC | revocation_endpoint | ICP WEB SSL | Obrigatório
 2 | Adiantamento | /unarranged-accounts-overdraft/* | ICP WEB SSL | Obrigatório
 2 | Direitos   Creditórios | /invoice-financings/* | ICP WEB SSL | Obrigatório
 3 | Pagamentos | /payments/* | ICP WEB SSL | Obrigatório
+
+(*) caso seja necessário a publicação do endpoint, o que não é obrigatório.

--- a/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
+++ b/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
@@ -316,23 +316,23 @@ otherName.0 = 2.16.76.1.3.3;UTF8:<CNPJ>
 ## Tabela com Endpoints vs Tipo de Certificado e mTLS
 Abaixo apresentamos quais endpoints podem ser publicados utilizando certificado EV como autenticação do consentimento e os endpoints de autenticação de APIs privadas/negócios que devem ser publicadas usando certificado ICP. Você também poderá verificar quais endpoints devem proteger suas conexões utilizando mTLS.
 
-Fase | Grupo | API | EV | ICP | mTLS
--- | -- | -- | -- | -- | --
-NA | OIDC | .well-known/openid-configuration | X | X |  
-NA | OIDC | jwks_uri | X | X |  
-NA | OIDC | authorization_endpoint | X |   |  
-NA | OIDC | token_endpoint |   | X | X
-NA | OIDC | userinfo_endpoint |   | X | X
-NA | OIDC | pushed_authorization_request_endpoint |   | X | X
-NA | DCR | registration_endpoint |   | X | X
-NA | OIDC | revocation_endpoint |   | X | X
-2 | Consentimentos | /consents/* |   | X | X
-2 | Resources | /resources/* |   | X | X
-2 | Dados | /customers/* |   | X | X
-2 | Cartão | /credit-cards-accounts/* |   | X | X
-2 | Contas | /accounts/* |   | X | X
-2 | Empréstimos | /loans/* |   | X | X
-2 | Financiamentos | /financings/* |   | X | X
-2 | Adiantamento | /unarranged-accounts-overdraft/* |   | X | X
-2 | Direitos   Creditórios | /invoice-financings/* |   | X | X
-3 | Pagamentos | /payments/* |   | X | X
+Fase | Grupo | API | Certificado | mTLS
+-- | -- | -- | -- |  --
+NA | OIDC | .well-known/openid-configuration | EV ou ICP WEB SSL |  
+NA | OIDC | jwks_uri | EV ou ICP WEB SSL |  
+NA | OIDC | authorization_endpoint | EV |   |  
+NA | OIDC | token_endpoint | ICP WEB SSL | Obrigatório
+NA | OIDC | userinfo_endpoint | ICP WEB SSL | Obrigatório
+NA | OIDC | pushed_authorization_request_endpoint |  ICP WEB SSL | Obrigatório
+NA | DCR | registration_endpoint |  ICP WEB SSL | Obrigatório
+NA | OIDC | revocation_endpoint | ICP WEB SSL | Obrigatório
+2 | Consentimentos | /consents/* |  ICP WEB SSL | Obrigatório
+2 | Resources | /resources/* | ICP WEB SSL | Obrigatório
+2 | Dados | /customers/* | ICP WEB SSL | Obrigatório
+2 | Cartão | /credit-cards-accounts/* | ICP WEB SSL | Obrigatório
+2 | Contas | /accounts/* | ICP WEB SSL | Obrigatório
+2 | Empréstimos | /loans/* | ICP WEB SSL | Obrigatório
+2 | Financiamentos | /financings/* | ICP WEB SSL | Obrigatório
+2 | Adiantamento | /unarranged-accounts-overdraft/* | ICP WEB SSL | Obrigatório
+2 | Direitos   Creditórios | /invoice-financings/* | ICP WEB SSL | Obrigatório
+3 | Pagamentos | /payments/* | ICP WEB SSL | Obrigatório

--- a/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
+++ b/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
@@ -95,7 +95,7 @@ Os seguintes documentos referenciados são indispensáveis para a aplicação de
 * [OBB-FAPI] - Open Banking Brasil Financial-grade API Security Profile 1.0 [OBB-FAPI]: <https://github.com/OpenBanking-Brasil/specs-seguranca/open-banking-brasil-financial-api-1_ID1.html>
 * [DOC-ICP-01] - DECLARAÇÃO DE PRÁTICAS DE CERTIFICAÇÃO DA AUTORIDADE CERTIFICADORA RAIZ DA ICP-BRASIL: <https://www.gov.br/iti/pt-br/centrais-de-conteudo/doc-icp-01-v-5-2-dpc-da-ac-raiz-da-icp-brasil-pdf>
 * [RFC6749] - The OAuth 2.0 Authorization Framework [RFC6749]: <https://tools.ietf.org/html/rfc6749>
-* [BCB-IN99] - Manual de Segurança do Open Banking: <https://www.in.gov.br/en/web/dou/-/instrucao-normativa-bcb-n-99-de-14-de-abril-de-2021-314641007>
+* [BCB-IN134] - Manual de Segurança do Open Banking: <https://www.bcb.gov.br/estabilidadefinanceira/exibenormativo?tipo=Instru%C3%A7%C3%A3o%20Normativa%20BCB&numero=134>
 * [RFC2818] - HTTP Over TLS: <https://datatracker.ietf.org/doc/html/rfc2818>
 
 # Termos e Definições {#TermosDefinicoes}
@@ -272,7 +272,7 @@ stateOrProvinceName = <UF>
 localityName = <Cidade>
 organizationalUnitName = <Código de Participante>
 UID = <Software Statement ID emitido pelo diretório>
-commonName = <FQDN|Wildcard>
+commonName = <FQDN>
 
 [ req_cert_extensions ]
 basicConstraints = CA:FALSE
@@ -281,7 +281,7 @@ keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth
 
 [ alt_name ]
-DNS = <FQDN|Wildcard>
+DNS = <FQDN>
 ```
 
 ## Modelo de Configuração de Certificado de Assinatura - OpenSSL {#ModeloConfiguracaoCertificadoAssinaturaOpenSSL}
@@ -311,8 +311,28 @@ subjectAltName = @alt_name
 keyUsage = critical,digitalSignature,nonRepudiation
 
 [ alt_name ]
-otherName.0 = 2.16.76.1.3.2;UTF8:<Nome da pessoal responsável pela entidade>#CNPJ
-otherName.1 = 2.16.76.1.3.3;UTF8:<CNPJ>
-otherName.2 = 2.16.76.1.3.4;UTF8:<CPF/PIS/RF da Pessoa responsável>
-otherName.3 = 2.16.76.1.3.7;UTF8:<Número de INSS>
+otherName.0 = 2.16.76.1.3.3;UTF8:<CNPJ>
 ```
+## Tabela com Endpoints vs Tipo de Certificado e mTLS
+Abaixo apresentamos quais endpoints podem ser publicados utilizando certificado EV como autenticação do consentimento e os endpoints de autenticação de APIs privadas/negócios que devem ser publicadas usando certificado ICP. Você também poderá verificar quais endpoints devem proteger suas conexões utilizando mTLS.
+
+Fase | Grupo | API | EV | ICP | mTLS
+-- | -- | -- | -- | -- | --
+NA | OIDC | .well-known/openid-configuration | X | X |  
+NA | OIDC | jwks_uri | X | X |  
+NA | OIDC | authorization_endpoint | X |   |  
+NA | OIDC | token_endpoint |   | X | X
+NA | OIDC | userinfo_endpoint |   | X | X
+NA | OIDC | pushed_authorization_request_endpoint |   | X | X
+NA | DCR | registration_endpoint |   | X | X
+NA | OIDC | revocation_endpoint |   | X | X
+2 | Consentimentos | /consents/* |   | X | X
+2 | Resources | /resources/* |   | X | X
+2 | Dados | /customers/* |   | X | X
+2 | Cartão | /credit-cards-accounts/* |   | X | X
+2 | Contas | /accounts/* |   | X | X
+2 | Empréstimos | /loans/* |   | X | X
+2 | Financiamentos | /financings/* |   | X | X
+2 | Adiantamento | /unarranged-accounts-overdraft/* |   | X | X
+2 | Direitos   Creditórios | /invoice-financings/* |   | X | X
+3 | Pagamentos | /payments/* |   | X | X

--- a/open-banking-brasil-certificate-standards-1_ID1.md
+++ b/open-banking-brasil-certificate-standards-1_ID1.md
@@ -329,6 +329,7 @@ NA | OIDC | userinfo_endpoint | ICP WEB SSL | Required
 NA | OIDC | pushed_authorization_request_endpoint |  ICP WEB SSL | Required
 NA | DCR | registration_endpoint |  ICP WEB SSL | Required
 NA | OIDC | revocation_endpoint | ICP WEB SSL | Required
+NA | OIDC | introspection_endpoint _(*)_ | ICP WEB SSL | Required
 2 | Consentimentos | /consents/* |  ICP WEB SSL | Required
 2 | Resources | /resources/* | ICP WEB SSL | Required
 2 | Dados | /customers/* | ICP WEB SSL | Required
@@ -339,3 +340,5 @@ NA | OIDC | revocation_endpoint | ICP WEB SSL | Required
 2 | Adiantamento | /unarranged-accounts-overdraft/* | ICP WEB SSL | Required
 2 | Direitos   Creditórios | /invoice-financings/* | ICP WEB SSL | Required
 3 | Pagamentos | /payments/* | ICP WEB SSL | Required
+
+_(*)_ if for some reason this endpoint should be public, which is not recommended.

--- a/open-banking-brasil-certificate-standards-1_ID1.md
+++ b/open-banking-brasil-certificate-standards-1_ID1.md
@@ -222,6 +222,12 @@ The following certifying authorities carried out the onboard process for Open Ba
 
 Front-End certificates are used to provide services, in general web pages, using TLS, which are accessed by the end user. Given their purpose, and to ensure greater interoperability, certificates must be of the EV (Extended Validation) type and must be generated through a valid certificte authority, following the rules defined in RFC 5280 and RFC 2818, in accordance with the principles and WebTrust criteria.
 
+### About certificates for exchanging information between Open Banking participating institutions and partners (non-participating)
+
+According to section IV of Joint Resolution No. 1 of May 4, 2020, the establishment of bilateral partnerships with non-participating institutions is an arrangement provided  in the regulation and which must observe, as appropriate, the same communication and security requirements that are applicable to information exchange between participating institutions.
+
+In accordance with §2 of Art. 10 of Provisional Measure 2200-2 of August 24, 2001 and with the provisions of item 3.12 in BCB Normative Instruction No. 134, for bilateral communication between institutions and partners, the use is authorized, by mutual agreement between the parties, of a private PKI, provided that the requirements of this _profile for security certificates_ are observed, including their formatting, algorithms and attributes. The values ​​for filling in attributes required in this specification but not applicable to the partner, must be defined in common agreement between the participating institution and the partner.
+
 # Acknowledgements
 
 With thanks to all who have set the foundations for secure and safe data sharing through the formation of the OpenID Foundation FAPI Working Group, the Open Banking Brasil GT Security and to the pioneers who will stand on their shoulders.
@@ -244,7 +250,7 @@ The technology described in this specification was made available from contribut
 
 # Appendix
 
-## Configuration Template for Client Certificate - OpenSSL 
+## Configuration Template for Client Certificate - OpenSSL
 
 ```
 [req]
@@ -268,13 +274,13 @@ organizationalUnitName = <PArticipante Code>
 UID = <Software Statement ID issued by the Directory>
 commonName = <FQDN|Wildcard>
 
-[ req_cert_extensions ] 
+[ req_cert_extensions ]
 basicConstraints = CA:FALSE
 subjectAltName = @alt_name
 keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth
 
-[ alt_name ] 
+[ alt_name ]
 DNS = <FQDN|Wildcard>
 ```
 
@@ -299,12 +305,12 @@ organizationName = ICP-Brasil
 2.organizationalUnitName = <Validation type>
 commonName = <Company Name>
 
-[ req_cert_extensions ] 
+[ req_cert_extensions ]
 basicConstraints = CA:FALSE
 subjectAltName = @alt_name
 keyUsage = critical,digitalSignature,nonRepudiation
 
-[ alt_name ] 
+[ alt_name ]
 otherName.0 = 2.16.76.1.3.2;UTF8:<Name of the person responsible for the organization>
 otherName.1 = 2.16.76.1.3.3;UTF8:<CNPJ>
 otherName.2 = 2.16.76.1.3.4;UTF8:<CPF/PIS/RF of responsible person>

--- a/open-banking-brasil-certificate-standards-1_ID1.md
+++ b/open-banking-brasil-certificate-standards-1_ID1.md
@@ -222,11 +222,13 @@ The following certifying authorities carried out the onboard process for Open Ba
 
 Front-End certificates are used to provide services, in general web pages, using TLS, which are accessed by the end user. Given their purpose, and to ensure greater interoperability, certificates must be of the EV (Extended Validation) type and must be generated through a valid certificte authority, following the rules defined in RFC 5280 and RFC 2818, in accordance with the principles and WebTrust criteria.
 
-### About certificates for exchanging information between Open Banking participating institutions and partners (non-participating)
+### About certificates for exchanging information between authorized institutions and partners (non-participating)
 
-According to section IV of Joint Resolution No. 1 of May 4, 2020, the establishment of bilateral partnerships with non-participating institutions is an arrangement provided  in the regulation and which must observe, as appropriate, the same communication and security requirements that are applicable to information exchange between participating institutions.
+According to section IV of Joint Resolution No. 1 of May 4, 2020, the establishment of bilateral partnerships between authorized institutions and partners is an arrangement provided in the regulation and which must observe, where applicable, the same standards and certificates requirements that are applicable to exchange of information between participating institutions.
 
-In accordance with §2 of Art. 10 of Provisional Measure 2200-2 of August 24, 2001 and with the provisions of item 3.12 in BCB Normative Instruction No. 134, for bilateral communication between institutions and partners, the use is authorized, by mutual agreement between the parties, of a private PKI, provided that the requirements of this _profile for security certificates_ are observed, including their formatting, algorithms and attributes. The values ​​for filling in attributes required in this specification but not applicable to the partner, must be defined in common agreement between the participating institution and the partner.
+In accordance with §2 of Art. 10 of Provisional Measure 2200-2 of August 24, 2001 and with the provisions of item 3.12 in BCB Normative Instruction No. 134, for bilateral communication between institutions and partners, the use is authorized, by mutual agreement between the parties, of a private PKI, provided that the requirements of this _profile for security certificates_ are observed, including their formatting, algorithms and established attributes.
+
+The values ​​for filling in the attributes required in this specification, but not applicable to the partner, should be defined in common agreement between the authorized institution and the partner, which does not exempt the authorized institution from the responsibility for filling it in properly.
 
 # Acknowledgements
 

--- a/open-banking-brasil-certificate-standards-1_ID1.md
+++ b/open-banking-brasil-certificate-standards-1_ID1.md
@@ -220,7 +220,7 @@ The following certifying authorities carried out the onboard process for Open Ba
 
 ### Front-End Certificates
 
-Front-End certificates are used to provide services, in general web pages, using TLS, which are accessed by the end user. Given their purpose, and to ensure greater interoperability, certificates must be of the EV (Extended Validation) type and must be generated through a valid certificte authority, following the rules defined in RFC 5280 and RFC 2818, in accordance with the principles and WebTrust criteria.
+x509 Certificates that are used to secure communication channels between end-users browsers and banks services must be trusted be issued by a certificate authority certified by the CA Browser Forum. In addition, and to ensure greater interoperability, certificates must meet the requirements for CAB Forum EV (Extended Validation), following the rules defined in RFC 5280 and RFC 2818, in accordance with the principles and WebTrust criteria.
 
 ### About certificates for exchanging information between authorized institutions and partners (non-participating)
 

--- a/open-banking-brasil-certificate-standards-1_ID1.md
+++ b/open-banking-brasil-certificate-standards-1_ID1.md
@@ -321,21 +321,21 @@ otherName.3 = 2.16.76.1.3.7;UTF8:<INSS Number>
 
 OBB phase | group | endpoint | certificate type | mTLS
 -- | -- | -- | -- |  --
-NA | OIDC | .well-known/openid-configuration | EV ou ICP WEB SSL |  
-NA | OIDC | jwks_uri | EV ou ICP WEB SSL |  
+NA | OIDC | .well-known/openid-configuration | EV or ICP WEB SSL |  
+NA | OIDC | jwks_uri | EV or ICP WEB SSL |  
 NA | OIDC | authorization_endpoint | EV |   |  
-NA | OIDC | token_endpoint | ICP WEB SSL | Obrigatório
-NA | OIDC | userinfo_endpoint | ICP WEB SSL | Obrigatório
-NA | OIDC | pushed_authorization_request_endpoint |  ICP WEB SSL | Obrigatório
-NA | DCR | registration_endpoint |  ICP WEB SSL | Obrigatório
-NA | OIDC | revocation_endpoint | ICP WEB SSL | Obrigatório
-2 | Consentimentos | /consents/* |  ICP WEB SSL | Obrigatório
-2 | Resources | /resources/* | ICP WEB SSL | Obrigatório
-2 | Dados | /customers/* | ICP WEB SSL | Obrigatório
-2 | Cartão | /credit-cards-accounts/* | ICP WEB SSL | Obrigatório
-2 | Contas | /accounts/* | ICP WEB SSL | Obrigatório
-2 | Empréstimos | /loans/* | ICP WEB SSL | Obrigatório
-2 | Financiamentos | /financings/* | ICP WEB SSL | Obrigatório
-2 | Adiantamento | /unarranged-accounts-overdraft/* | ICP WEB SSL | Obrigatório
-2 | Direitos   Creditórios | /invoice-financings/* | ICP WEB SSL | Obrigatório
-3 | Pagamentos | /payments/* | ICP WEB SSL | Obrigatório
+NA | OIDC | token_endpoint | ICP WEB SSL | Required
+NA | OIDC | userinfo_endpoint | ICP WEB SSL | Required
+NA | OIDC | pushed_authorization_request_endpoint |  ICP WEB SSL | Required
+NA | DCR | registration_endpoint |  ICP WEB SSL | Required
+NA | OIDC | revocation_endpoint | ICP WEB SSL | Required
+2 | Consentimentos | /consents/* |  ICP WEB SSL | Required
+2 | Resources | /resources/* | ICP WEB SSL | Required
+2 | Dados | /customers/* | ICP WEB SSL | Required
+2 | Cartão | /credit-cards-accounts/* | ICP WEB SSL | Required
+2 | Contas | /accounts/* | ICP WEB SSL | Required
+2 | Empréstimos | /loans/* | ICP WEB SSL | Required
+2 | Financiamentos | /financings/* | ICP WEB SSL | Required
+2 | Adiantamento | /unarranged-accounts-overdraft/* | ICP WEB SSL | Required
+2 | Direitos   Creditórios | /invoice-financings/* | ICP WEB SSL | Required
+3 | Pagamentos | /payments/* | ICP WEB SSL | Required

--- a/open-banking-brasil-certificate-standards-1_ID1.md
+++ b/open-banking-brasil-certificate-standards-1_ID1.md
@@ -316,3 +316,26 @@ otherName.1 = 2.16.76.1.3.3;UTF8:<CNPJ>
 otherName.2 = 2.16.76.1.3.4;UTF8:<CPF/PIS/RF of responsible person>
 otherName.3 = 2.16.76.1.3.7;UTF8:<INSS Number>
 ```
+
+## Endpoints vs Certificate type and mTLS requirements
+
+OBB phase | group | endpoint | certificate type | mTLS
+-- | -- | -- | -- |  --
+NA | OIDC | .well-known/openid-configuration | EV ou ICP WEB SSL |  
+NA | OIDC | jwks_uri | EV ou ICP WEB SSL |  
+NA | OIDC | authorization_endpoint | EV |   |  
+NA | OIDC | token_endpoint | ICP WEB SSL | Obrigatório
+NA | OIDC | userinfo_endpoint | ICP WEB SSL | Obrigatório
+NA | OIDC | pushed_authorization_request_endpoint |  ICP WEB SSL | Obrigatório
+NA | DCR | registration_endpoint |  ICP WEB SSL | Obrigatório
+NA | OIDC | revocation_endpoint | ICP WEB SSL | Obrigatório
+2 | Consentimentos | /consents/* |  ICP WEB SSL | Obrigatório
+2 | Resources | /resources/* | ICP WEB SSL | Obrigatório
+2 | Dados | /customers/* | ICP WEB SSL | Obrigatório
+2 | Cartão | /credit-cards-accounts/* | ICP WEB SSL | Obrigatório
+2 | Contas | /accounts/* | ICP WEB SSL | Obrigatório
+2 | Empréstimos | /loans/* | ICP WEB SSL | Obrigatório
+2 | Financiamentos | /financings/* | ICP WEB SSL | Obrigatório
+2 | Adiantamento | /unarranged-accounts-overdraft/* | ICP WEB SSL | Obrigatório
+2 | Direitos   Creditórios | /invoice-financings/* | ICP WEB SSL | Obrigatório
+3 | Pagamentos | /payments/* | ICP WEB SSL | Obrigatório

--- a/open-banking-brasil-dynamic-client-registration-1_ID1-ptbr.md
+++ b/open-banking-brasil-dynamic-client-registration-1_ID1-ptbr.md
@@ -250,7 +250,7 @@ Quando as propriedades de uma solicitação DCR não estão incluídas e não s�
 
 A cláusula 3 do [Lightweight Directory Access Protocol (LDAP): String Representation of Distinguished Names][RFC4514] define os OIDs obrigatórios cujas as _strings_ do AttributeType (descritores) devem ser reconhecidos pelos implementadores. Esta lista obrigatória não inclui vários dos OIDs definidos em [Open Banking Brasil x.509 Certificate Standards][OBB-Cert-Standards], nem existe um mecanismo definido para os Servidores de Autorização publicarem informações sobre o formato que eles esperam de uma Solicitação Dinâmica de Registro do Cliente (_Dynamic Client Registrarion_) que inclui um `tls_client_auth_subject_dn`.
 
-Para resolver essa ambigüidade, o Servidor de Autorização deve aceitar todas as strings de nome de AttributeType (descritores) definidas no último parágrafo da cláusula 3 [RFC4515], além de todos os AttributeTypes definidos no Distinguished Name [Open Banking Brasil x.509 Certificate Standards][OBB-Cert-Standards].
+Para resolver essa ambigüidade, o Servidor de Autorização deve aceitar todas as strings de nome de AttributeType (descritores) definidas no último parágrafo da cláusula 3 [RFC4514], além de todos os AttributeTypes definidos no Distinguished Name [Open Banking Brasil x.509 Certificate Standards][OBB-Cert-Standards].
 
 ## Funções regulatórias para mapeamentos OpenID e OAuth 2.0  {#Regs}
 

--- a/open-banking-brasil-dynamic-client-registration-1_ID1-ptbr.md
+++ b/open-banking-brasil-dynamic-client-registration-1_ID1-ptbr.md
@@ -252,6 +252,20 @@ A cláusula 3 do [Lightweight Directory Access Protocol (LDAP): String Represent
 
 Para resolver essa ambigüidade, o Servidor de Autorização deve aceitar todas as strings de nome de AttributeType (descritores) definidas no último parágrafo da cláusula 3 [RFC4514], além de todos os AttributeTypes definidos no Distinguished Name [Open Banking Brasil x.509 Certificate Standards][OBB-Cert-Standards].
 
+Segue na tabela abaixo alguns exemplos de decodificação:
+
+- Obtenha na ordem reversa os atributos do certificado
+- Concatene cada RDN (RelativeDistinguishedName) com uma virgula (',')
+- Use as strings da RFC (CN, L, ST, O, OU, C, Street, DC, UID) + os nomes dos atributos definidos nesta especificação para uso no OBB (businessCategory, jurisdictionCountryName , serialNumber)
+
+Exemplos:
+subject_dn | Issuer
+-- | --
+UID=67c57882-043b-11ec-9a03-0242ac130003,jurisdictionCountryName=BR,businessCategory=Private      Organization,serialNumber=00038166000954,CN=mycn.bank.com.br,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=MY BANK SA,L=SAO PAULO,ST=SP,C=BR | issuer=CN=Open Banking SANDBOX Issuing CA   - G1,OU=Open Banking,O=Open   Banking Brasil,C=BR
+UID=67c57882-043b-11ec-9a03-0242ac130003,   jurisdictionCountryName=BR,businessCategory=Business Entity,CN=mycn.bank.gov.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=My Public Bank,L=BRASILIA,ST=DF,C=BR | issuer=CN=Autoridade Certificadora do SERPRO SSLv1,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR,jurisdictionCountryName=BR,businessCategory=Private
+Organization,UID=67c57882-043b-11ec-9a03-0242ac130003,CN=openbanking.mybank.com.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Goiania,ST=GO,O=MyBank SA,C=BR | issuer=CN=AC SOLUTI SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR
+CN=mycn.bank.com.br,UID=67c57882-043b-11ec-9a03-0242ac130003,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Sao   Paulo,ST=SP,O=MyBank SA,C=BR,serialNumber=00038166000954,   jurisdictionCountryName=BR,businessCategory=Private   Organization | issuer=CN=AC SERASA SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR
+
 ## Funções regulatórias para mapeamentos OpenID e OAuth 2.0  {#Regs}
 
 Para participar do ecossistema do Open Banking, as instituições credenciadas devem se cadastrar no Diretório de Participantes de acordo com seus papéis regulatórios. Essas funções refletem a autorização do Banco Central para as instituições e, consequentemente, as APIs que podem utilizar.

--- a/open-banking-brasil-dynamic-client-registration-1_ID1-ptbr.md
+++ b/open-banking-brasil-dynamic-client-registration-1_ID1-ptbr.md
@@ -259,12 +259,12 @@ Segue na tabela abaixo alguns exemplos de decodificação:
 - Use as strings da RFC (CN, L, ST, O, OU, C, Street, DC, UID) + os nomes dos atributos definidos nesta especificação para uso no OBB (businessCategory, jurisdictionCountryName , serialNumber)
 
 Exemplos:
-subject_dn | Issuer
--- | --
-UID=67c57882-043b-11ec-9a03-0242ac130003,jurisdictionCountryName=BR,businessCategory=Private      Organization,serialNumber=00038166000954,CN=mycn.bank.com.br,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=MY BANK SA,L=SAO PAULO,ST=SP,C=BR | issuer=CN=Open Banking SANDBOX Issuing CA   - G1,OU=Open Banking,O=Open   Banking Brasil,C=BR
-UID=67c57882-043b-11ec-9a03-0242ac130003,   jurisdictionCountryName=BR,businessCategory=Business Entity,CN=mycn.bank.gov.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=My Public Bank,L=BRASILIA,ST=DF,C=BR | issuer=CN=Autoridade Certificadora do SERPRO SSLv1,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR,jurisdictionCountryName=BR,businessCategory=Private
-Organization,UID=67c57882-043b-11ec-9a03-0242ac130003,CN=openbanking.mybank.com.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Goiania,ST=GO,O=MyBank SA,C=BR | issuer=CN=AC SOLUTI SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR
-CN=mycn.bank.com.br,UID=67c57882-043b-11ec-9a03-0242ac130003,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Sao   Paulo,ST=SP,O=MyBank SA,C=BR,serialNumber=00038166000954,   jurisdictionCountryName=BR,businessCategory=Private   Organization | issuer=CN=AC SERASA SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR
+| subject_dn | Issuer |
+| -- | -- |
+| UID=67c57882-043b-11ec-9a03-0242ac130003,jurisdictionCountryName=BR,businessCategory=Private      Organization,serialNumber=00038166000954,CN=mycn.bank.com.br,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=MY BANK SA,L=SAO PAULO,ST=SP,C=BR | issuer=CN=Open Banking SANDBOX Issuing CA   - G1,OU=Open Banking,O=Open   Banking Brasil,C=BR |
+| UID=67c57882-043b-11ec-9a03-0242ac130003,   jurisdictionCountryName=BR,businessCategory=Business Entity,CN=mycn.bank.gov.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=My Public Bank,L=BRASILIA,ST=DF,C=BR | issuer=CN=Autoridade Certificadora do SERPRO SSLv1,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR,jurisdictionCountryName=BR,businessCategory=Private |
+| Organization,UID=67c57882-043b-11ec-9a03-0242ac130003,CN=openbanking.mybank.com.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Goiania,ST=GO,O=MyBank SA,C=BR | issuer=CN=AC SOLUTI SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR |
+| CN=mycn.bank.com.br,UID=67c57882-043b-11ec-9a03-0242ac130003,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Sao   Paulo,ST=SP,O=MyBank SA,C=BR,serialNumber=00038166000954,   jurisdictionCountryName=BR,businessCategory=Private   Organization | issuer=CN=AC SERASA SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR |
 
 ## Funções regulatórias para mapeamentos OpenID e OAuth 2.0  {#Regs}
 

--- a/open-banking-brasil-dynamic-client-registration-1_ID1.md
+++ b/open-banking-brasil-dynamic-client-registration-1_ID1.md
@@ -257,14 +257,12 @@ In terms of format, the Security WG have defined the examples in bellow:
 - Use RFC Strings (CN, L, ST, O, OU, C, Street, DC, UID) + OBB Certificate Specs (businessCategory, jurisdictionCountryName , serialNumber)
 
 Examples:
-subject_dn | Issuer
--- | --
-subject_dn | Issuer
--- | --
-UID=67c57882-043b-11ec-9a03-0242ac130003,jurisdictionCountryName=BR,businessCategory=Private      Organization,serialNumber=00038166000954,CN=mycn.bank.com.br,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=MY BANK SA,L=SAO PAULO,ST=SP,C=BR | issuer=CN=Open Banking SANDBOX Issuing CA   - G1,OU=Open Banking,O=Open   Banking Brasil,C=BR
-UID=67c57882-043b-11ec-9a03-0242ac130003,   jurisdictionCountryName=BR,businessCategory=Business Entity,CN=mycn.bank.gov.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=My Public Bank,L=BRASILIA,ST=DF,C=BR | issuer=CN=Autoridade Certificadora do SERPRO SSLv1,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR,jurisdictionCountryName=BR,businessCategory=Private
-Organization,UID=67c57882-043b-11ec-9a03-0242ac130003,CN=openbanking.mybank.com.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Goiania,ST=GO,O=MyBank SA,C=BR | issuer=CN=AC SOLUTI SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR
-CN=mycn.bank.com.br,UID=67c57882-043b-11ec-9a03-0242ac130003,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Sao   Paulo,ST=SP,O=MyBank SA,C=BR,serialNumber=00038166000954,   jurisdictionCountryName=BR,businessCategory=Private   Organization | issuer=CN=AC SERASA SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR
+| subject_dn | Issuer |
+| -- | -- |
+| UID=67c57882-043b-11ec-9a03-0242ac130003,jurisdictionCountryName=BR,businessCategory=Private      Organization,serialNumber=00038166000954,CN=mycn.bank.com.br,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=MY BANK SA,L=SAO PAULO,ST=SP,C=BR | issuer=CN=Open Banking SANDBOX Issuing CA   - G1,OU=Open Banking,O=Open   Banking Brasil,C=BR |
+| UID=67c57882-043b-11ec-9a03-0242ac130003,   jurisdictionCountryName=BR,businessCategory=Business Entity,CN=mycn.bank.gov.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=My Public Bank,L=BRASILIA,ST=DF,C=BR | issuer=CN=Autoridade Certificadora do SERPRO SSLv1,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR,jurisdictionCountryName=BR,businessCategory=Private |
+| Organization,UID=67c57882-043b-11ec-9a03-0242ac130003,CN=openbanking.mybank.com.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Goiania,ST=GO,O=MyBank SA,C=BR | issuer=CN=AC SOLUTI SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR |
+| CN=mycn.bank.com.br,UID=67c57882-043b-11ec-9a03-0242ac130003,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Sao   Paulo,ST=SP,O=MyBank SA,C=BR,serialNumber=00038166000954,   jurisdictionCountryName=BR,businessCategory=Private   Organization | issuer=CN=AC SERASA SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR |
 
 ## Regulatory Roles to OpenID and OAuth 2.0 Mappings
 

--- a/open-banking-brasil-dynamic-client-registration-1_ID1.md
+++ b/open-banking-brasil-dynamic-client-registration-1_ID1.md
@@ -250,6 +250,22 @@ Clause 3 of [Lightweight Directory Access Protocol (LDAP): String Representation
 
 To address this ambiguity, the Authorization Server must accept all AttributeType name strings (descriptors) defined in the last paragraph of clause 3 [RFC4514] in addition to all of the AttributeTypes defined in the Distinguished Name of the [Open Banking Brasil x.509 Certificate Standards][OBB-Cert-Standards].
 
+In terms of format, the Security WG have defined the examples in bellow:
+
+- Start backwards, the order is reversed from what is entered.
+- Append each RDN (RelativeDistinguishedName) segment with a comma ‘,’
+- Use RFC Strings (CN, L, ST, O, OU, C, Street, DC, UID) + OBB Certificate Specs (businessCategory, jurisdictionCountryName , serialNumber)
+
+Examples:
+subject_dn | Issuer
+-- | --
+subject_dn | Issuer
+-- | --
+UID=67c57882-043b-11ec-9a03-0242ac130003,jurisdictionCountryName=BR,businessCategory=Private      Organization,serialNumber=00038166000954,CN=mycn.bank.com.br,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=MY BANK SA,L=SAO PAULO,ST=SP,C=BR | issuer=CN=Open Banking SANDBOX Issuing CA   - G1,OU=Open Banking,O=Open   Banking Brasil,C=BR
+UID=67c57882-043b-11ec-9a03-0242ac130003,   jurisdictionCountryName=BR,businessCategory=Business Entity,CN=mycn.bank.gov.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,O=My Public Bank,L=BRASILIA,ST=DF,C=BR | issuer=CN=Autoridade Certificadora do SERPRO SSLv1,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR,jurisdictionCountryName=BR,businessCategory=Private
+Organization,UID=67c57882-043b-11ec-9a03-0242ac130003,CN=openbanking.mybank.com.br,serialNumber=00038166000954,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Goiania,ST=GO,O=MyBank SA,C=BR | issuer=CN=AC SOLUTI SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR
+CN=mycn.bank.com.br,UID=67c57882-043b-11ec-9a03-0242ac130003,OU=497e1ffe-b2a2-4a4e-8ef0-70633fd11b59,L=Sao   Paulo,ST=SP,O=MyBank SA,C=BR,serialNumber=00038166000954,   jurisdictionCountryName=BR,businessCategory=Private   Organization | issuer=CN=AC SERASA SSL EV,OU=Autoridade   Certificadora Raiz Brasileira v10,O=ICP-Brasil,C=BR
+
 ## Regulatory Roles to OpenID and OAuth 2.0 Mappings
 
 To participate in the Open Banking ecosystem, accredited institutions must register themselves in the directory of participants according to their regulatory roles. Those roles reflect the institutions' authorization from the Central Bank and, consequently, the APIs they are allowed to use.

--- a/open-banking-brasil-dynamic-client-registration-1_ID1.md
+++ b/open-banking-brasil-dynamic-client-registration-1_ID1.md
@@ -248,7 +248,7 @@ Where properties of a DCR request are not included and are not mandatory in the 
 
 Clause 3 of [Lightweight Directory Access Protocol (LDAP): String Representation of Distinguished Names][RFC4514] defines the mandatory OIDs whose AttributeType strings (descriptors) must be recognized by implementers. This mandatory list does not include several of the OIDs defined in [Open Banking Brasil x.509 Certificate Standards][OBB-Cert-Standards] nor is there a defined mechanism for Authorisation Servers to publish  information regarding the format that they would expect a Dynamic Client Registration request that includes a `tls_client_auth_subject_dn` to be presented in.
 
-To address this ambiguity, the Authorization Server must accept all AttributeType name strings (descriptors) defined in the last paragraph of clause 3 [RFC4515] in addition to all of the AttributeTypes defined in the Distinguished Name of the [Open Banking Brasil x.509 Certificate Standards][OBB-Cert-Standards].
+To address this ambiguity, the Authorization Server must accept all AttributeType name strings (descriptors) defined in the last paragraph of clause 3 [RFC4514] in addition to all of the AttributeTypes defined in the Distinguished Name of the [Open Banking Brasil x.509 Certificate Standards][OBB-Cert-Standards].
 
 ## Regulatory Roles to OpenID and OAuth 2.0 Mappings
 

--- a/open-banking-brasil-financial-api-1_ID2-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID2-ptbr.md
@@ -272,10 +272,15 @@ Nome: cnpj, Tipo: Array of Strings, Array Element Regex: '^\d{14}$'
 * **LoA2**: mecanismo de autenticação com a adoção de um único fator
 * **LoA3**: mecanismo de autenticação com múltiplos fatores de autenticação
 
-A seguinte regra deve ser adotada para o mecanismo de autenticação:
+A seguinte orientação deve ser observada para o mecanismo de autenticação:
 
-* **Para controle de acesso às API´s definidas na FASE 2 (leitura de dados)**: os `Authorization Servers` das instituições transmissoras de dados devem condicionar a autenticação do usuário proprietário do dado, no mínimo, a adoção de método compatível com `LoA2`. A adoção de mecanismo de autenticação mais rigoroso (`LoA3`) fica a critério da instituição transmissora de acordo com sua avaliação de riscos.
-* **Para acesso às API´s das fases subsequentes (em especial pagamento)**: o acesso deve ser condicionado à método de autenticação compatível com `LoA3` ou superior.  
+Sobre os mecanismos de autenticação:
+* De acordo com o Art. 17 da Resolução Conjunta nº 01, as instituições devem adotar  procedimentos e controles para autenticação de cliente **compatíveis com os aplicáveis ao acesso a seus canais de atendimento eletrônicos**.
+* Em observância à regulação em vigor, sugere-se que:
+  * **Para a autenticação do usuário em autorizações de acessos às APIs de compartilhamento de dados (Fase 2)**, os `Authorization Servers` **deveriam** adotar, no mínimo, método compatível com `LoA2`; e
+  * **Para a autenticação do usuário em autorizações de acessos às API´s das fases subsequentes**, os `Authorization Servers` **deveriam** adotar método de autenticação compatível com `LoA3` ou superior.
+
+Em todos os casos, a adoção de mecanismo de autenticação mais rigoroso (`LoA3` ou superior) fica a critério da instituição transmissora ou detentora de conta, de acordo com sua avaliação de riscos e de forma compatível com os mecanismos habitualmente utilizados. Portanto, o cliente de API **não deve** estabelecer na claim `acr` qualquer método a ser exigido, mas o método adotado pelo ASPSP **deve** ser retornado pelo `Authorization Server` na claim `acr` conforme estabelecido nesta definição.
 
 **Esclarecimentos adicionais sobre fatores de autenticação**
 

--- a/open-banking-brasil-financial-api-1_ID2-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID2-ptbr.md
@@ -272,11 +272,9 @@ Nome: cnpj, Tipo: Array of Strings, Array Element Regex: '^\d{14}$'
 * **LoA2**: mecanismo de autenticação com a adoção de um único fator
 * **LoA3**: mecanismo de autenticação com múltiplos fatores de autenticação
 
-A seguinte orientação deve ser observada para o mecanismo de autenticação:
-* De acordo com o Art. 17 da Resolução Conjunta nº 01, as instituições devem adotar  procedimentos e controles para autenticação de cliente **compatíveis com os aplicáveis ao acesso a seus canais de atendimento eletrônicos**.
-* Em observância à regulação em vigor, sugere-se que:
-  * **Para a autenticação do usuário em autorizações de acessos às APIs de compartilhamento de dados (Fase 2)**, os _Authorization Servers_ **deveriam** adotar, no mínimo, método compatível com `LoA2`; e
-  * **Para a autenticação do usuário em autorizações de acessos às API´s das fases subsequentes**, os _Authorization Servers_ **deveriam** adotar método de autenticação compatível com `LoA3` ou superior.
+A seguinte regra deve ser adotada para o mecanismo de autenticação:
+* **Para controle de acesso às API´s definidas na FASE 2 (leitura de dados)**: os `Authorization Servers` das instituições transmissoras de dados devem condicionar a autenticação do usuário proprietário do dado, no mínimo, a adoção de método compatível com `LoA2`. A adoção de mecanismo de autenticação mais rigoroso (`LoA3`) fica a critério da instituição transmissora de acordo com sua avaliação de riscos.
+* **Para acesso às API´s das fases subsequentes (em especial pagamento)**: o acesso deve ser condicionado à método de autenticação compatível com `LoA3` ou superior. 
 
 Em todos os casos, a adoção de mecanismo de autenticação mais rigoroso (`LoA3` ou superior) fica a critério da instituição transmissora ou detentora de conta, de acordo com sua avaliação de riscos e de forma compatível com os mecanismos habitualmente utilizados. Portanto, o cliente de API **não deve** estabelecer na claim `acr` qualquer método a ser exigido, mas o método adotado pelo ASPSP **deve** ser retornado pelo _Authorization Server_ na claim `acr` conforme estabelecido nesta definição.
 

--- a/open-banking-brasil-financial-api-1_ID2-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID2-ptbr.md
@@ -273,14 +273,12 @@ Nome: cnpj, Tipo: Array of Strings, Array Element Regex: '^\d{14}$'
 * **LoA3**: mecanismo de autenticação com múltiplos fatores de autenticação
 
 A seguinte orientação deve ser observada para o mecanismo de autenticação:
-
-Sobre os mecanismos de autenticação:
 * De acordo com o Art. 17 da Resolução Conjunta nº 01, as instituições devem adotar  procedimentos e controles para autenticação de cliente **compatíveis com os aplicáveis ao acesso a seus canais de atendimento eletrônicos**.
 * Em observância à regulação em vigor, sugere-se que:
-  * **Para a autenticação do usuário em autorizações de acessos às APIs de compartilhamento de dados (Fase 2)**, os `Authorization Servers` **deveriam** adotar, no mínimo, método compatível com `LoA2`; e
-  * **Para a autenticação do usuário em autorizações de acessos às API´s das fases subsequentes**, os `Authorization Servers` **deveriam** adotar método de autenticação compatível com `LoA3` ou superior.
+  * **Para a autenticação do usuário em autorizações de acessos às APIs de compartilhamento de dados (Fase 2)**, os _Authorization Servers_ **deveriam** adotar, no mínimo, método compatível com `LoA2`; e
+  * **Para a autenticação do usuário em autorizações de acessos às API´s das fases subsequentes**, os _Authorization Servers_ **deveriam** adotar método de autenticação compatível com `LoA3` ou superior.
 
-Em todos os casos, a adoção de mecanismo de autenticação mais rigoroso (`LoA3` ou superior) fica a critério da instituição transmissora ou detentora de conta, de acordo com sua avaliação de riscos e de forma compatível com os mecanismos habitualmente utilizados. Portanto, o cliente de API **não deve** estabelecer na claim `acr` qualquer método a ser exigido, mas o método adotado pelo ASPSP **deve** ser retornado pelo `Authorization Server` na claim `acr` conforme estabelecido nesta definição.
+Em todos os casos, a adoção de mecanismo de autenticação mais rigoroso (`LoA3` ou superior) fica a critério da instituição transmissora ou detentora de conta, de acordo com sua avaliação de riscos e de forma compatível com os mecanismos habitualmente utilizados. Portanto, o cliente de API **não deve** estabelecer na claim `acr` qualquer método a ser exigido, mas o método adotado pelo ASPSP **deve** ser retornado pelo _Authorization Server_ na claim `acr` conforme estabelecido nesta definição.
 
 **Esclarecimentos adicionais sobre fatores de autenticação**
 

--- a/open-banking-brasil-financial-api-1_ID2-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID2-ptbr.md
@@ -274,9 +274,7 @@ Nome: cnpj, Tipo: Array of Strings, Array Element Regex: '^\d{14}$'
 
 A seguinte regra deve ser adotada para o mecanismo de autenticação:
 * **Para controle de acesso às API´s definidas na FASE 2 (leitura de dados)**: os `Authorization Servers` das instituições transmissoras de dados devem condicionar a autenticação do usuário proprietário do dado, no mínimo, a adoção de método compatível com `LoA2`. A adoção de mecanismo de autenticação mais rigoroso (`LoA3`) fica a critério da instituição transmissora de acordo com sua avaliação de riscos.
-* **Para acesso às API´s das fases subsequentes (em especial pagamento)**: o acesso deve ser condicionado à método de autenticação compatível com `LoA3` ou superior. 
-
-Em todos os casos, a adoção de mecanismo de autenticação mais rigoroso (`LoA3` ou superior) fica a critério da instituição transmissora ou detentora de conta, de acordo com sua avaliação de riscos e de forma compatível com os mecanismos habitualmente utilizados. Portanto, o cliente de API **não deve** estabelecer na claim `acr` qualquer método a ser exigido, mas o método adotado pelo ASPSP **deve** ser retornado pelo _Authorization Server_ na claim `acr` conforme estabelecido nesta definição.
+* **Para acesso às API´s das fases subsequentes (em especial pagamento)**: o acesso deve ser condicionado à método de autenticação compatível com `LoA3` ou superior.
 
 **Esclarecimentos adicionais sobre fatores de autenticação**
 

--- a/open-banking-brasil-financial-api-1_ID2.md
+++ b/open-banking-brasil-financial-api-1_ID2.md
@@ -284,14 +284,10 @@ This profile defines "urn:brasil:openbanking:loa2" and "urn:brasil:openbanking:l
 * **LoA2:** Authentication performed using single factor;
 * **LoA3:** Authentication performed using multi factor (MFA)
 
-The following rules are applicable to **access control to Open Banking Brazil API´s:**
+The following rules are applicable:
 
-* In accordance to Art. 17 of [Joint Resolution nº 01 - Open Banking Brasil](https://www.in.gov.br/en/web/dou/-/resolucao-conjunta-n-1-de-4-de-maio-de-2020-255165055), institutions must adopt procedures and controls for client authentication **compatible with those applicable in their electronic service channels**.
-* So, in compliance with the regulation, it is suggested that:
-   * **For Read-Only APIs  (Phase 2)**: the _Authorization Servers_ **should** adopt, at least, an authentication method compatible with `LoA2`; and
-   * **For Read-Write API´s (subsequent phases)**: the _Authorization Servers_ **should** adopt an authentication method compatible with `LoA3` or higher.
-
-In all cases, the adoption of a more rigorous authentication mechanism (`LoA3` or higher) is at the discretion of the Bank (ASPSP), according to its risk assessment and in a manner compatible with the mechanisms usually used. So, the API client (TTP/PISP) **shall not** define any value to `acr` claim, but the method adopted by ASPSP **shall** be presented at `acr` claim returned by _Authorization Server_.
+* * **Read-only APIs :** shall require resource owner authentication to at least LoA2, elevating the requirement to authenticate resource owners to LoA3 is at the discretion of the Authorization Server;
+* **Read-and-Write APIs (Transactional):** shall require resource owner authentication to at least LoA3.
 
 **Authentication factors clarification**
 

--- a/open-banking-brasil-financial-api-1_ID2.md
+++ b/open-banking-brasil-financial-api-1_ID2.md
@@ -284,10 +284,14 @@ This profile defines "urn:brasil:openbanking:loa2" and "urn:brasil:openbanking:l
 * **LoA2:** Authentication performed using single factor;
 * **LoA3:** Authentication performed using multi factor (MFA)
 
-The following rules are applicable:
+The following rules are applicable to **access control to Open Banking Brazil API´s:**
 
-* **Read-only APIs :** shall require resource owner authentication to at least LoA2, elevating the requirement to authenticate resource owners to LoA3 is at the discretion of the Authorization Server;
-* **Read-and-Write APIs (Transactional):** shall require resource owner authentication to at least LoA3.
+* In accordance to Art. 17 of [Joint Resolution nº 01 - Open Banking Brasil](https://www.in.gov.br/en/web/dou/-/resolucao-conjunta-n-1-de-4-de-maio-de-2020-255165055), institutions must adopt procedures and controls for client authentication **compatible with those applicable in their electronic service channels**.
+* So, in compliance with the regulation, it is suggested that:
+   * **For Read-Only APIs  (Phase 2)**: the `Authorization Servers` **should** adopt, at least, an authentication method compatible with `LoA2`; and
+   * **For Read-Write API´s (subsequent phases)**: the `Authorization Servers` **should** adopt an authentication method compatible with `LoA3` or higher.
+
+In all cases, the adoption of a more rigorous authentication mechanism (`LoA3` or higher) is at the discretion of the Bank (ASPSP), according to its risk assessment and in a manner compatible with the mechanisms usually used. So, the API client (TTP/PISP) **shall not** define any value to `acr` claim, but the method adopted by ASPSP **shall** be presented at `acr` claim returned by `Authorization Server`.
 
 **Authentication factors clarification**
 

--- a/open-banking-brasil-financial-api-1_ID2.md
+++ b/open-banking-brasil-financial-api-1_ID2.md
@@ -288,10 +288,10 @@ The following rules are applicable to **access control to Open Banking Brazil AP
 
 * In accordance to Art. 17 of [Joint Resolution nº 01 - Open Banking Brasil](https://www.in.gov.br/en/web/dou/-/resolucao-conjunta-n-1-de-4-de-maio-de-2020-255165055), institutions must adopt procedures and controls for client authentication **compatible with those applicable in their electronic service channels**.
 * So, in compliance with the regulation, it is suggested that:
-   * **For Read-Only APIs  (Phase 2)**: the `Authorization Servers` **should** adopt, at least, an authentication method compatible with `LoA2`; and
-   * **For Read-Write API´s (subsequent phases)**: the `Authorization Servers` **should** adopt an authentication method compatible with `LoA3` or higher.
+   * **For Read-Only APIs  (Phase 2)**: the _Authorization Servers_ **should** adopt, at least, an authentication method compatible with `LoA2`; and
+   * **For Read-Write API´s (subsequent phases)**: the _Authorization Servers_ **should** adopt an authentication method compatible with `LoA3` or higher.
 
-In all cases, the adoption of a more rigorous authentication mechanism (`LoA3` or higher) is at the discretion of the Bank (ASPSP), according to its risk assessment and in a manner compatible with the mechanisms usually used. So, the API client (TTP/PISP) **shall not** define any value to `acr` claim, but the method adopted by ASPSP **shall** be presented at `acr` claim returned by `Authorization Server`.
+In all cases, the adoption of a more rigorous authentication mechanism (`LoA3` or higher) is at the discretion of the Bank (ASPSP), according to its risk assessment and in a manner compatible with the mechanisms usually used. So, the API client (TTP/PISP) **shall not** define any value to `acr` claim, but the method adopted by ASPSP **shall** be presented at `acr` claim returned by _Authorization Server_.
 
 **Authentication factors clarification**
 

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -404,7 +404,8 @@ Além dos requisitos descritos nas disposições de segurança do Open Banking B
 7. deve manter registros sobre o histórico dos consentimento para permitir a adequada formação de trilhas de auditoria em conformidade com a regulação em vigor;
 8. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o CPF do usuário autenticado não seja o mesmo indicado no elemento _loggedUser_ do Consentimento (Consent Resource Object);
 9. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o elemento _businessEntity_ não tenha sido preenchido no Consentimento (Consent Resource Object) relacionado e o usuário tenha selecionado ou se autenticado por meio de credencial relacionada à conta do tipo Pessoa Jurídica (PJ);
-10. deve condicionar a autenticação ou seleção de contas do tipo PJ à consistência entre o CNPJ relacionado à(s) conta(s) e o valor presente no elemento _businessEntity_ do Consentimento (Consent Resource Object). Em caso de divergência deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]).
+10. deve condicionar a autenticação ou seleção de contas do tipo PJ à consistência entre o CNPJ relacionado à(s) conta(s) e o valor presente no elemento _businessEntity_ do Consentimento (Consent Resource Object). Em caso de divergência deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]);
+11. o _refresh_token_ emitido deve permanecer válido enquanto o consentimento ao qual está relacionado for válido. 
 
 ### Cliente confidencial  {#clientconfidential}
 

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -405,7 +405,7 @@ Além dos requisitos descritos nas disposições de segurança do Open Banking B
 8. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o CPF do usuário autenticado não seja o mesmo indicado no elemento _loggedUser_ do Consentimento (Consent Resource Object);
 9. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o elemento _businessEntity_ não tenha sido preenchido no Consentimento (Consent Resource Object) relacionado e o usuário tenha selecionado ou se autenticado por meio de credencial relacionada à conta do tipo Pessoa Jurídica (PJ);
 10. deve condicionar a autenticação ou seleção de contas do tipo PJ à consistência entre o CNPJ relacionado à(s) conta(s) e o valor presente no elemento _businessEntity_ do Consentimento (Consent Resource Object). Em caso de divergência deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]);
-11. o _refresh_token_ emitido deve permanecer válido enquanto o consentimento ao qual está relacionado for válido. 
+11. o _refresh_token_ emitido deve ter a mesma validade do consentimento ao qual está relacionado. 
 
 ### Cliente confidencial  {#clientconfidential}
 

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -272,10 +272,15 @@ Nome: cnpj, Tipo: Array of Strings, Array Element Regex: '^\d{14}$'
 * **LoA2**: mecanismo de autenticação com a adoção de um único fator
 * **LoA3**: mecanismo de autenticação com múltiplos fatores de autenticação
 
-A seguinte regra deve ser adotada para o mecanismo de autenticação:
+A seguinte orientação deve ser observada para o mecanismo de autenticação:
 
-* **Para controle de acesso às API´s definidas na FASE 2 (leitura de dados)**: os `Authorization Servers` das instituições transmissoras de dados devem condicionar a autenticação do usuário proprietário do dado, no mínimo, a adoção de método compatível com `LoA2`. A adoção de mecanismo de autenticação mais rigoroso (`LoA3`) fica a critério da instituição transmissora de acordo com sua avaliação de riscos.
-* **Para acesso às API´s das fases subsequentes (em especial pagamento)**: o acesso deve ser condicionado à método de autenticação compatível com `LoA3` ou superior.  
+Sobre os mecanismos de autenticação:
+* De acordo com o Art. 17 da Resolução Conjunta nº 01, as instituições devem adotar  procedimentos e controles para autenticação de cliente **compatíveis com os aplicáveis ao acesso a seus canais de atendimento eletrônicos**.
+* Em observância à regulação em vigor, sugere-se que:
+  * **Para a autenticação do usuário em autorizações de acessos às APIs de compartilhamento de dados (Fase 2)**, os `Authorization Servers` **deveriam** adotar, no mínimo, método compatível com `LoA2`; e
+  * **Para a autenticação do usuário em autorizações de acessos às API´s das fases subsequentes**, os `Authorization Servers` **deveriam** adotar método de autenticação compatível com `LoA3` ou superior.
+
+Em todos os casos, a adoção de mecanismo de autenticação mais rigoroso (`LoA3` ou superior) fica a critério da instituição transmissora ou detentora de conta, de acordo com sua avaliação de riscos e de forma compatível com os mecanismos habitualmente utilizados. Portanto, o cliente de API **não deve** estabelecer na claim `acr` qualquer método a ser exigido, mas o método adotado pelo ASPSP **deve** ser retornado pelo `Authorization Server` na claim `acr` conforme estabelecido nesta definição.
 
 **Esclarecimentos adicionais sobre fatores de autenticação**
 

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -225,8 +225,7 @@ Além disso, ele deve:
 8. deve implementar o endpoint "userinfo" como definido no item 5.3 do [OpenID Connect Core][OIDC]
 9. deve suportar o escopo parametrizável ("parameterized OAuth 2.0 resource scope") _consent_ como definido no item 6.3.1 de [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 10. pode suportar [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA]
-11. deve suportar [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] se suportar o scope _payments_
-###>> 11a. deve suportar [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] se suportar o scope _xxxxx_ (ou seja, caso ofereça APIs que exijam fluxo desacoplado como no encaminhamento de proposta de crédito)
+11. (requisito temporariamente retirado)
 12. deve suportar `refresh tokens`
 13. deve emitir `access tokens` com o tempo de expiração entre 300 (mínimo) e 900 (máximo) segundos
 14. deve sempre incluir a claim `acr` no id_token

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -273,14 +273,12 @@ Nome: cnpj, Tipo: Array of Strings, Array Element Regex: '^\d{14}$'
 * **LoA3**: mecanismo de autenticação com múltiplos fatores de autenticação
 
 A seguinte orientação deve ser observada para o mecanismo de autenticação:
-
-Sobre os mecanismos de autenticação:
 * De acordo com o Art. 17 da Resolução Conjunta nº 01, as instituições devem adotar  procedimentos e controles para autenticação de cliente **compatíveis com os aplicáveis ao acesso a seus canais de atendimento eletrônicos**.
 * Em observância à regulação em vigor, sugere-se que:
-  * **Para a autenticação do usuário em autorizações de acessos às APIs de compartilhamento de dados (Fase 2)**, os `Authorization Servers` **deveriam** adotar, no mínimo, método compatível com `LoA2`; e
-  * **Para a autenticação do usuário em autorizações de acessos às API´s das fases subsequentes**, os `Authorization Servers` **deveriam** adotar método de autenticação compatível com `LoA3` ou superior.
+  * **Para a autenticação do usuário em autorizações de acessos às APIs de compartilhamento de dados (Fase 2)**, os _Authorization Servers_ **deveriam** adotar, no mínimo, método compatível com `LoA2`; e
+  * **Para a autenticação do usuário em autorizações de acessos às API´s das fases subsequentes**, os _Authorization Servers_ **deveriam** adotar método de autenticação compatível com `LoA3` ou superior.
 
-Em todos os casos, a adoção de mecanismo de autenticação mais rigoroso (`LoA3` ou superior) fica a critério da instituição transmissora ou detentora de conta, de acordo com sua avaliação de riscos e de forma compatível com os mecanismos habitualmente utilizados. Portanto, o cliente de API **não deve** estabelecer na claim `acr` qualquer método a ser exigido, mas o método adotado pelo ASPSP **deve** ser retornado pelo `Authorization Server` na claim `acr` conforme estabelecido nesta definição.
+Em todos os casos, a adoção de mecanismo de autenticação mais rigoroso (`LoA3` ou superior) fica a critério da instituição transmissora ou detentora de conta, de acordo com sua avaliação de riscos e de forma compatível com os mecanismos habitualmente utilizados. Portanto, o cliente de API **não deve** estabelecer na claim `acr` qualquer método a ser exigido, mas o método adotado pelo ASPSP **deve** ser retornado pelo _Authorization Server_ na claim `acr` conforme estabelecido nesta definição.
 
 **Esclarecimentos adicionais sobre fatores de autenticação**
 

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -226,6 +226,7 @@ Além disso, ele deve:
 9. deve suportar o escopo parametrizável ("parameterized OAuth 2.0 resource scope") _consent_ como definido no item 6.3.1 de [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 10. pode suportar [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA]
 11. deve suportar [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] se suportar o scope _payments_
+###>> 11a. deve suportar [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] se suportar o scope _xxxxx_ (ou seja, caso ofereça APIs que exijam fluxo desacoplado como no encaminhamento de proposta de crédito)
 12. deve suportar `refresh tokens`
 13. deve emitir `access tokens` com o tempo de expiração entre 300 (mínimo) e 900 (máximo) segundos
 14. deve sempre incluir a claim `acr` no id_token
@@ -303,7 +304,8 @@ Além disso, o cliente confidencial
 3. deve usar objetos de solicitação _encrypted_ se não usar [PAR]
 4. deve suportar o escopo de recurso OAuth 2.0 parametrizado _consent_ conforme definido na cláusula 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 5. deve suportar `refresh tokens`
-6. não deve incluir um valor específico na claim `acr` caso defina a _claim_ `acr`como _essential_
+6. não deve incluir um valor específico na _claim_ `acr`
+7. deve definir a _claim_ `acr`como _essential_
 
 # Considerações de segurança  {#authserver}
 
@@ -407,7 +409,7 @@ Além dos requisitos descritos nas disposições de segurança do Open Banking B
 8. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o CPF do usuário autenticado não seja o mesmo indicado no elemento _loggedUser_ do Consentimento (Consent Resource Object);
 9. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o elemento _businessEntity_ não tenha sido preenchido no Consentimento (Consent Resource Object) relacionado e o usuário tenha selecionado ou se autenticado por meio de credencial relacionada à conta do tipo Pessoa Jurídica (PJ);
 10. deve condicionar a autenticação ou seleção de contas do tipo PJ à consistência entre o CNPJ relacionado à(s) conta(s) e o valor presente no elemento _businessEntity_ do Consentimento (Consent Resource Object). Em caso de divergência deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]);
-11. o _refresh_token_ emitido deve ter a mesma validade do consentimento ao qual está relacionado.
+11. o _refresh_token_ emitido não deve ser inferior à validade do consentimento ao qual está relacionado, respeitado os demais critérios acima.
 
 ### Cliente confidencial  {#clientconfidential}
 

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -227,7 +227,8 @@ Além disso, ele deve:
 10. pode suportar [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA]
 11. deve suportar [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] se suportar o scope _payments_
 12. deve suportar `refresh tokens`
-13. deve emitir `access tokens` com o tempo de expiração entre 300 (mínimo) e 900 (máximo) segundos.
+13. deve emitir `access tokens` com o tempo de expiração entre 300 (mínimo) e 900 (máximo) segundos
+14. deve sempre incluir a claim `acr` no id_token
 
 #### Token de ID como assinatura separada  {#detached}
 
@@ -278,7 +279,7 @@ A seguinte orientação deve ser observada para o mecanismo de autenticação:
   * **Para a autenticação do usuário em autorizações de acessos às APIs de compartilhamento de dados (Fase 2)**, os _Authorization Servers_ **deveriam** adotar, no mínimo, método compatível com `LoA2`; e
   * **Para a autenticação do usuário em autorizações de acessos às API´s das fases subsequentes**, os _Authorization Servers_ **deveriam** adotar método de autenticação compatível com `LoA3` ou superior.
 
-Em todos os casos, a adoção de mecanismo de autenticação mais rigoroso (`LoA3` ou superior) fica a critério da instituição transmissora ou detentora de conta, de acordo com sua avaliação de riscos e de forma compatível com os mecanismos habitualmente utilizados. Portanto, o cliente de API **não deve** estabelecer na claim `acr` qualquer método a ser exigido, mas o método adotado pelo ASPSP **deve** ser retornado pelo _Authorization Server_ na claim `acr` conforme estabelecido nesta definição.
+Em todos os casos, a adoção de mecanismo de autenticação mais rigoroso (`LoA3` ou superior) fica a critério da instituição transmissora ou detentora de conta, de acordo com sua avaliação de riscos e de forma compatível com os mecanismos habitualmente utilizados.
 
 **Esclarecimentos adicionais sobre fatores de autenticação**
 
@@ -302,6 +303,7 @@ Além disso, o cliente confidencial
 3. deve usar objetos de solicitação _encrypted_ se não usar [PAR]
 4. deve suportar o escopo de recurso OAuth 2.0 parametrizado _consent_ conforme definido na cláusula 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 5. deve suportar `refresh tokens`
+6. não deve incluir um valor específico na claim `acr` caso defina a _claim_ `acr`como _essential_
 
 # Considerações de segurança  {#authserver}
 
@@ -405,7 +407,7 @@ Além dos requisitos descritos nas disposições de segurança do Open Banking B
 8. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o CPF do usuário autenticado não seja o mesmo indicado no elemento _loggedUser_ do Consentimento (Consent Resource Object);
 9. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o elemento _businessEntity_ não tenha sido preenchido no Consentimento (Consent Resource Object) relacionado e o usuário tenha selecionado ou se autenticado por meio de credencial relacionada à conta do tipo Pessoa Jurídica (PJ);
 10. deve condicionar a autenticação ou seleção de contas do tipo PJ à consistência entre o CNPJ relacionado à(s) conta(s) e o valor presente no elemento _businessEntity_ do Consentimento (Consent Resource Object). Em caso de divergência deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]);
-11. o _refresh_token_ emitido deve ter a mesma validade do consentimento ao qual está relacionado. 
+11. o _refresh_token_ emitido deve ter a mesma validade do consentimento ao qual está relacionado.
 
 ### Cliente confidencial  {#clientconfidential}
 

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -408,7 +408,7 @@ Além dos requisitos descritos nas disposições de segurança do Open Banking B
 8. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o CPF do usuário autenticado não seja o mesmo indicado no elemento _loggedUser_ do Consentimento (Consent Resource Object);
 9. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o elemento _businessEntity_ não tenha sido preenchido no Consentimento (Consent Resource Object) relacionado e o usuário tenha selecionado ou se autenticado por meio de credencial relacionada à conta do tipo Pessoa Jurídica (PJ);
 10. deve condicionar a autenticação ou seleção de contas do tipo PJ à consistência entre o CNPJ relacionado à(s) conta(s) e o valor presente no elemento _businessEntity_ do Consentimento (Consent Resource Object). Em caso de divergência deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]);
-11. o _refresh_token_ emitido não deve ser inferior à validade do consentimento ao qual está relacionado, respeitado os demais critérios acima.
+11. deve emitir _refresh_token_ com validade não inferior à validade do consentimento ao qual está relacionado, respeitado os demais critérios acima.
 
 ### Cliente confidencial  {#clientconfidential}
 

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -317,7 +317,8 @@ In addition, the confidential client
 3. shall use _encrypted_ request objects if not using [PAR]
 4. shall support parameterized OAuth 2.0 resource scope _consent_ as defined in clause 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 5. shall support refresh tokens
-6. shall not request specific `acr` values if requesting `acr` as an essential claim
+6. shall not populate the `acr` claim with required values
+7. shall require the `acr` claim as an essential claim
 
 # Security considerations
 

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -284,10 +284,14 @@ This profile defines "urn:brasil:openbanking:loa2" and "urn:brasil:openbanking:l
 * **LoA2:** Authentication performed using single factor;
 * **LoA3:** Authentication performed using multi factor (MFA)
 
-The following rules are applicable:
+The following rules are applicable to **access control to Open Banking Brazil API´s:**
 
-* **Read-only APIs :** shall require resource owner authentication to at least LoA2, elevating the requirement to authenticate resource owners to LoA3 is at the discretion of the Authorization Server;
-* **Read-and-Write APIs (Transactional):** shall require resource owner authentication to at least LoA3.
+* In accordance to Art. 17 of [Joint Resolution nº 01 - Open Banking Brasil](https://www.in.gov.br/en/web/dou/-/resolucao-conjunta-n-1-de-4-de-maio-de-2020-255165055), institutions must adopt procedures and controls for client authentication **compatible with those applicable in their electronic service channels**.
+* So, in compliance with the regulation, it is suggested that:
+   * **For Read-Only APIs  (Phase 2)**: the `Authorization Servers` **should** adopt, at least, an authentication method compatible with `LoA2`; and
+   * **For Read-Write API´s (subsequent phases)**: the `Authorization Servers` **should** adopt an authentication method compatible with `LoA3` or higher.
+
+In all cases, the adoption of a more rigorous authentication mechanism (`LoA3` or higher) is at the discretion of the Bank (ASPSP), according to its risk assessment and in a manner compatible with the mechanisms usually used. So, the API client (TTP/PISP) **shall not** define any value to `acr` claim, but the method adopted by ASPSP **shall** be presented at `acr` claim returned by `Authorization Server`.
 
 **Authentication factors clarification**
 

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -222,11 +222,13 @@ In addition, the Authorization Server
 6. shall support the acr "urn:brasil:openbanking:loa2" as defined in clause 5.2.2.4 of this document
 7. should support the acr "urn:brasil:openbanking:loa3" as defined in clause 5.2.2.4 of this document
 8. shall implement the userinfo endpoint as defined in clause 5.3 [OpenID Connect Core][OIDC]
-10. shall support parameterized OAuth 2.0 resource scope _consent_ as defined in clause 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
-11. may support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA]
-12. shall support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] if supporting scope _payments_
-13. shall support refresh tokens
-14. shall issue access tokens with an expiry no greater than 900 seconds and no less than 300 seconds
+9. shall support parameterized OAuth 2.0 resource scope _consent_ as defined in clause 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
+10. may support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA]
+11. shall support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] if supporting scope _payments_
+12. shall support refresh tokens
+13. shall issue access tokens with an expiry no greater than 900 seconds and no less than 300 seconds
+14. shall always include an acr claim in the id_token
+
 
 #### ID Token as detached signature
 
@@ -291,7 +293,7 @@ The following rules are applicable to **access control to Open Banking Brazil AP
    * **For Read-Only APIs  (Phase 2)**: the _Authorization Servers_ **should** adopt, at least, an authentication method compatible with `LoA2`; and
    * **For Read-Write API´s (subsequent phases)**: the _Authorization Servers_ **should** adopt an authentication method compatible with `LoA3` or higher.
 
-In all cases, the adoption of a more rigorous authentication mechanism (`LoA3` or higher) is at the discretion of the Bank (ASPSP), according to its risk assessment and in a manner compatible with the mechanisms usually used. So, the API client (TTP/PISP) **shall not** define any value to `acr` claim, but the method adopted by ASPSP **shall** be presented at `acr` claim returned by _Authorization Server_.
+In all cases, the adoption of a more rigorous authentication mechanism (`LoA3` or higher) is at the discretion of the Bank (ASPSP), according to its risk assessment and in a manner compatible with the mechanisms usually used.
 
 **Authentication factors clarification**
 
@@ -315,6 +317,7 @@ In addition, the confidential client
 3. shall use _encrypted_ request objects if not using [PAR]
 4. shall support parameterized OAuth 2.0 resource scope _consent_ as defined in clause 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 5. shall support refresh tokens
+6. shall not request specific `acr` values if requesting `acr` as an essential claim
 
 # Security considerations
 
@@ -417,7 +420,7 @@ In addition to the requirements outlined in Open Banking Brasil security provisi
 8. shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]) if the CPF of the authenticated user is not the same as indicated in the _loggedUser_ element of the Consent Resource Object;
 9. shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]) if the _businessEntity_ element has not been populated in the related Consent Resource Object and the user has selected or authenticated by using a credential related to a business account;
 10. an autenticated or selected business account´s CNPJ must match the value present in the _businessEntity_ element of the Consent Resource Object. In case of divergence authorization server shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]);
-11. an issued _refresh_token_ shall be valid until the linked Consent Resource object is still valid.
+11. shall ensure _refresh_tokens_ expiration time is at least equal to the linked consent resource expiration time.
 
 ### Confidential Client
 

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -288,10 +288,10 @@ The following rules are applicable to **access control to Open Banking Brazil AP
 
 * In accordance to Art. 17 of [Joint Resolution nº 01 - Open Banking Brasil](https://www.in.gov.br/en/web/dou/-/resolucao-conjunta-n-1-de-4-de-maio-de-2020-255165055), institutions must adopt procedures and controls for client authentication **compatible with those applicable in their electronic service channels**.
 * So, in compliance with the regulation, it is suggested that:
-   * **For Read-Only APIs  (Phase 2)**: the `Authorization Servers` **should** adopt, at least, an authentication method compatible with `LoA2`; and
-   * **For Read-Write API´s (subsequent phases)**: the `Authorization Servers` **should** adopt an authentication method compatible with `LoA3` or higher.
+   * **For Read-Only APIs  (Phase 2)**: the _Authorization Servers_ **should** adopt, at least, an authentication method compatible with `LoA2`; and
+   * **For Read-Write API´s (subsequent phases)**: the _Authorization Servers_ **should** adopt an authentication method compatible with `LoA3` or higher.
 
-In all cases, the adoption of a more rigorous authentication mechanism (`LoA3` or higher) is at the discretion of the Bank (ASPSP), according to its risk assessment and in a manner compatible with the mechanisms usually used. So, the API client (TTP/PISP) **shall not** define any value to `acr` claim, but the method adopted by ASPSP **shall** be presented at `acr` claim returned by `Authorization Server`.
+In all cases, the adoption of a more rigorous authentication mechanism (`LoA3` or higher) is at the discretion of the Bank (ASPSP), according to its risk assessment and in a manner compatible with the mechanisms usually used. So, the API client (TTP/PISP) **shall not** define any value to `acr` claim, but the method adopted by ASPSP **shall** be presented at `acr` claim returned by _Authorization Server_.
 
 **Authentication factors clarification**
 

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -225,7 +225,7 @@ In addition, the Authorization Server
 10. shall support parameterized OAuth 2.0 resource scope _consent_ as defined in clause 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 11. may support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA]
 12. shall support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] if supporting scope _payments_
-13. shall support refresh tokens issued with an expiry time defined with the same value as Consent Object
+13. shall support refresh tokens
 14. shall issue access tokens with an expiry no greater than 900 seconds and no less than 300 seconds
 
 #### ID Token as detached signature

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -224,10 +224,10 @@ In addition, the Authorization Server
 8. shall implement the userinfo endpoint as defined in clause 5.3 [OpenID Connect Core][OIDC]
 9. shall support parameterized OAuth 2.0 resource scope _consent_ as defined in clause 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 10. may support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA]
-11. shall support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] if supporting scope _payments_
+11. (withdrawn)
 12. shall support refresh tokens
 13. shall issue access tokens with an expiry no greater than 900 seconds and no less than 300 seconds
-14. shall always include an acr claim in the id_token
+14. shall always include an acr claim in the `id_token`
 
 
 #### ID Token as detached signature

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -225,7 +225,7 @@ In addition, the Authorization Server
 10. shall support parameterized OAuth 2.0 resource scope _consent_ as defined in clause 6.3.1 [OIDF FAPI WG Lodging Intent Pattern][LIWP]
 11. may support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA]
 12. shall support [Financial-grade API: Client Initiated Backchannel Authentication Profile][FAPI-CIBA] if supporting scope _payments_
-13. shall support refresh tokens
+13. shall support refresh tokens issued with an expiry time defined with the same value as Consent Object
 14. shall issue access tokens with an expiry no greater than 900 seconds and no less than 300 seconds
 
 #### ID Token as detached signature
@@ -416,7 +416,8 @@ In addition to the requirements outlined in Open Banking Brasil security provisi
 7. shall retain a complete audit history of the consent resource in accordance with current Central Bank brazilian regulation;
 8. shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]) if the CPF of the authenticated user is not the same as indicated in the _loggedUser_ element of the Consent Resource Object;
 9. shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]) if the _businessEntity_ element has not been populated in the related Consent Resource Object and the user has selected or authenticated by using a credential related to a business account;
-10. an autenticated or selected business account´s CNPJ must match the value present in the _businessEntity_ element of the Consent Resource Object. In case of divergence authorization server shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]).
+10. an autenticated or selected business account´s CNPJ must match the value present in the _businessEntity_ element of the Consent Resource Object. In case of divergence authorization server shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]);
+11. an issued _refresh_token_ shall be valid until the linked Consent Resource object is still valid.
 
 ### Confidential Client
 

--- a/tpp-user-guide-ptbr.md
+++ b/tpp-user-guide-ptbr.md
@@ -123,7 +123,7 @@ O exemplo acima é apresentado decodificado logo abaixo. No cabeçalho está inc
         "essential": true
       }
     },
-    "user_info": {
+    "userinfo": {
       "auth_time": {
         "essential": true
       },
@@ -794,7 +794,7 @@ BODY {
         "essential": true
       }
     },
-    "user_info": {
+    "userinfo": {
       "auth_time": {
         "essential": true
       },


### PR DESCRIPTION
Ajustes na tabela de certificados/endpoints, typo no TTP User Guide BR, expiração do refresh_token, ajustes Loa3, certificados para parceiros.

Enspoints / certificates table compliment, Type at portuguese TTP User Guide, refresh_token expiration (same as consent) , certificate to "regulatory" partners (portuguise only)