### PR TITLE
Include a note into DCR/DCM to match PT-BR Doc #198

### DIFF
--- a/open-banking-brasil-dynamic-client-registration-1_ID2.md
+++ b/open-banking-brasil-dynamic-client-registration-1_ID2.md
@@ -458,6 +458,8 @@ To extend [RFC7591] and [RFC7592], which recommend minimum mechanisms for authen
 1. validate that the certificate presented by the client application is subordinate to the ICP-Brasil chains defined in the Open Banking Brasil Certificates Standard; 
 2. Validate the presence and matching of the Bearer header `Authorization` containing the value of the `registration_access_token` attribute returned during registration of the corresponding client. 
 
+Note: [RFC7592] provides the possibility of rotating the `registration_access_token` issued by the Authorization Server with each use, making it a single-use token. When registering their client applications, institutions should consider this aspect to receive and update the `registration_access_token` for the new value received in client maintenance (DCM) operations.
+
 # Acknowledgement
 
 With thanks to all who have set the foundations for secure and safe data sharing through the formation of the OpenID Foundation FAPI Working Group, the Open Banking Brasil GT Security and to the pioneers who will stand on their shoulders.


### PR DESCRIPTION
The PTBR DCR DCM doc has a sentence:

Observação: A [RFC7592] prevê a possibilidade de rotação do registration_access_token emitido pelo Servidor de Autorização a cada uso, tornando-o um token de uso único. As instituições devem considerar esse aspecto no registro de suas aplicações cliente para receber e atualizar o registration_access_token pelo novo valor recebido nas chamadas de manutenção de cliente.

It's just a translated version to adjust the docs:

Note: [RFC7592] provides the possibility of rotating the `registration_access_token` issued by the Authorization Server with each use, making it a single-use token. When registering their client applications, institutions should consider this aspect to receive and update the `registration_access_token` for the new value received in client maintenance (DCM) operations.

Fix Doc and Close #198