### PR TITLE
ft_id05_wellknown

### DIFF
--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -232,6 +232,11 @@ Além disso, ele deve:
 15. deve suportar os valores `code` e `id_token` para o atributo `response_type`;
 16. pode suportar o valor `code` para o atributo `response_type`em conjunto com o valor `jwt` para o atributo `response_mode`;
 17. não deve permitir o recurso de rotação de `refresh tokens`.
+18. deve garantir que em caso de compartilhamento di Servidor de Autorização para outros serviços, além do Open Banking, não divulgue e/ou possibilite o uso de métodos não certificados no ambiente do Open Banking
+19. dve garantir que as configurações divulgadas aos demais participantes através do `OpenID Discovery` (indicado pelo arquivo de `Well-Known` cadastrado no Diretório) sejam restritos aos modos de operação aos quais a instituição se certificou
+  1. deve manter em suas configurações os métodos para os quais ainda hajam clientes ativos
+  2. deve atualizar os cadastros que utilizem métodos não certificados, através de tratamento bilateral entre as instituições envolvidas
+20. deve recusar requisições, para o ambiente do Open Banking, que estejam fora dos modos de operação ao qual a instituição certificou seu Servidor de Autorização
 
 #### Token de ID como assinatura separada  {#detached}
 

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -231,12 +231,12 @@ Além disso, ele deve:
 14. deve sempre incluir a claim `acr` no id_token;
 15. deve suportar os valores `code` e `id_token` para o atributo `response_type`;
 16. pode suportar o valor `code` para o atributo `response_type`em conjunto com o valor `jwt` para o atributo `response_mode`;
-17. não deve permitir o recurso de rotação de `refresh tokens`.
-18. deve garantir que em caso de compartilhamento di Servidor de Autorização para outros serviços, além do Open Banking, não divulgue e/ou possibilite o uso de métodos não certificados no ambiente do Open Banking
-19. dve garantir que as configurações divulgadas aos demais participantes através do `OpenID Discovery` (indicado pelo arquivo de `Well-Known` cadastrado no Diretório) sejam restritos aos modos de operação aos quais a instituição se certificou
-    1. deve manter em suas configurações os métodos para os quais ainda hajam clientes ativos
-    2. deve atualizar os cadastros que utilizem métodos não certificados, através de tratamento bilateral entre as instituições envolvidas
-20. deve recusar requisições, para o ambiente do Open Banking, que estejam fora dos modos de operação ao qual a instituição certificou seu Servidor de Autorização
+17. não deve permitir o recurso de rotação de `refresh tokens`;
+18. deve garantir que em caso de compartilhamento do Servidor de Autorização para outros serviços, além do Open Banking, não divulgue e/ou possibilite o uso de métodos não certificados no ambiente do Open Banking;
+19. dve garantir que as configurações divulgadas aos demais participantes através do `OpenID Discovery` (indicado pelo arquivo de `Well-Known` cadastrado no Diretório) sejam restritos aos modos de operação aos quais a instituição se certificou;
+    1. deve manter em suas configurações os métodos para os quais ainda hajam clientes ativos;
+    2. deve atualizar os cadastros que utilizem métodos não certificados, através de tratamento bilateral entre as instituições envolvidas.
+20. deve recusar requisições, para o ambiente do Open Banking, que estejam fora dos modos de operação ao qual a instituição certificou seu Servidor de Autorização.
 
 #### Token de ID como assinatura separada  {#detached}
 

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -233,7 +233,7 @@ Além disso, ele deve:
 16. pode suportar o valor `code` para o atributo `response_type`em conjunto com o valor `jwt` para o atributo `response_mode`;
 17. não deve permitir o recurso de rotação de `refresh tokens`;
 18. deve garantir que em caso de compartilhamento do Servidor de Autorização para outros serviços, além do Open Banking, não divulgue e/ou possibilite o uso de métodos não certificados no ambiente do Open Banking;
-19. dve garantir que as configurações divulgadas aos demais participantes através do `OpenID Discovery` (indicado pelo arquivo de `Well-Known` cadastrado no Diretório) sejam restritos aos modos de operação aos quais a instituição se certificou;
+19. deve garantir que as configurações divulgadas aos demais participantes através do `OpenID Discovery` (indicado pelo arquivo de `Well-Known` cadastrado no Diretório) sejam restritos aos modos de operação aos quais a instituição se certificou;
     1. deve manter em suas configurações os métodos para os quais ainda hajam clientes ativos;
     2. deve atualizar os cadastros que utilizem métodos não certificados, através de tratamento bilateral entre as instituições envolvidas.
 20. deve recusar requisições, para o ambiente do Open Banking, que estejam fora dos modos de operação ao qual a instituição certificou seu Servidor de Autorização.

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -234,8 +234,8 @@ Além disso, ele deve:
 17. não deve permitir o recurso de rotação de `refresh tokens`.
 18. deve garantir que em caso de compartilhamento di Servidor de Autorização para outros serviços, além do Open Banking, não divulgue e/ou possibilite o uso de métodos não certificados no ambiente do Open Banking
 19. dve garantir que as configurações divulgadas aos demais participantes através do `OpenID Discovery` (indicado pelo arquivo de `Well-Known` cadastrado no Diretório) sejam restritos aos modos de operação aos quais a instituição se certificou
-   1. deve manter em suas configurações os métodos para os quais ainda hajam clientes ativos
-   2. deve atualizar os cadastros que utilizem métodos não certificados, através de tratamento bilateral entre as instituições envolvidas
+    1. deve manter em suas configurações os métodos para os quais ainda hajam clientes ativos
+    2. deve atualizar os cadastros que utilizem métodos não certificados, através de tratamento bilateral entre as instituições envolvidas
 20. deve recusar requisições, para o ambiente do Open Banking, que estejam fora dos modos de operação ao qual a instituição certificou seu Servidor de Autorização
 
 #### Token de ID como assinatura separada  {#detached}

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -234,8 +234,8 @@ Além disso, ele deve:
 17. não deve permitir o recurso de rotação de `refresh tokens`.
 18. deve garantir que em caso de compartilhamento di Servidor de Autorização para outros serviços, além do Open Banking, não divulgue e/ou possibilite o uso de métodos não certificados no ambiente do Open Banking
 19. dve garantir que as configurações divulgadas aos demais participantes através do `OpenID Discovery` (indicado pelo arquivo de `Well-Known` cadastrado no Diretório) sejam restritos aos modos de operação aos quais a instituição se certificou
-  1. deve manter em suas configurações os métodos para os quais ainda hajam clientes ativos
-  2. deve atualizar os cadastros que utilizem métodos não certificados, através de tratamento bilateral entre as instituições envolvidas
+   1. deve manter em suas configurações os métodos para os quais ainda hajam clientes ativos
+   2. deve atualizar os cadastros que utilizem métodos não certificados, através de tratamento bilateral entre as instituições envolvidas
 20. deve recusar requisições, para o ambiente do Open Banking, que estejam fora dos modos de operação ao qual a instituição certificou seu Servidor de Autorização
 
 #### Token de ID como assinatura separada  {#detached}

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -231,6 +231,11 @@ In addition, the Authorization Server
 15. shall support the `response_type` value `code id_token`;
 16. may support `response_type` value `code` in conjunction with the `response_mode` value `jwt`;
 17. shall not allow `refresh tokens` rotation feature.
+18. shall ensure that, in case of sharing the Authorization Server for other services, in addition to Open Banking, it does not disclose and/or allow the use of non-certified methods in the Open Banking environment
+19. shall ensure that the settings disclosed to other participants through `OpenID Discovery` (indicated by the `Well-Known` file registered in the Directory) are restricted to the operating modes to which the institution has certified
+   1. shall keep in your settings the methods for which there are still active clients
+   2. shall update the records that use non-certified methods, through bilateral treatment between the institutions involved
+20. shall refuse requests, for the Open Banking environment, that are outside the modes of operation to which the institution has certified its Authorization Server
 
 #### ID Token as detached signature
 

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -233,8 +233,8 @@ In addition, the Authorization Server
 17. shall not allow `refresh tokens` rotation feature.
 18. shall ensure that, in case of sharing the Authorization Server for other services, in addition to Open Banking, it does not disclose and/or allow the use of non-certified methods in the Open Banking environment
 19. shall ensure that the settings disclosed to other participants through `OpenID Discovery` (indicated by the `Well-Known` file registered in the Directory) are restricted to the operating modes to which the institution has certified
-   a. shall keep in your settings the methods for which there are still active clients
-   b. shall update the records that use non-certified methods, through bilateral treatment between the institutions involved
+    1. shall keep in your settings the methods for which there are still active clients
+    2. shall update the records that use non-certified methods, through bilateral treatment between the institutions involved
 20. shall refuse requests, for the Open Banking environment, that are outside the modes of operation to which the institution has certified its Authorization Server
 
 #### ID Token as detached signature

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -230,12 +230,12 @@ In addition, the Authorization Server
 14. shall always include an acr claim in the `id_token`;
 15. shall support the `response_type` value `code id_token`;
 16. may support `response_type` value `code` in conjunction with the `response_mode` value `jwt`;
-17. shall not allow `refresh tokens` rotation feature.
-18. shall ensure that, in case of sharing the Authorization Server for other services, in addition to Open Banking, it does not disclose and/or allow the use of non-certified methods in the Open Banking environment
-19. shall ensure that the settings disclosed to other participants through `OpenID Discovery` (indicated by the `Well-Known` file registered in the Directory) are restricted to the operating modes to which the institution has certified
-    1. shall keep in your settings the methods for which there are still active clients
-    2. shall update the records that use non-certified methods, through bilateral treatment between the institutions involved
-20. shall refuse requests, for the Open Banking environment, that are outside the modes of operation to which the institution has certified its Authorization Server
+17. shall not allow `refresh tokens` rotation feature;
+18. shall ensure that, in case of sharing the Authorization Server for other services, in addition to Open Banking, it does not disclose and/or allow the use of non-certified methods in the Open Banking environment;
+19. shall ensure that the settings disclosed to other participants through `OpenID Discovery` (indicated by the `Well-Known` file registered in the Directory) are restricted to the operating modes to which the institution has certified;
+    1. shall keep in your settings the methods for which there are still active clients;
+    2. shall update the records that use non-certified methods, through bilateral treatment between the institutions involved.
+20. shall refuse requests, for the Open Banking environment, that are outside the modes of operation to which the institution has certified its Authorization Server.
 
 #### ID Token as detached signature
 

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -233,8 +233,8 @@ In addition, the Authorization Server
 17. shall not allow `refresh tokens` rotation feature.
 18. shall ensure that, in case of sharing the Authorization Server for other services, in addition to Open Banking, it does not disclose and/or allow the use of non-certified methods in the Open Banking environment
 19. shall ensure that the settings disclosed to other participants through `OpenID Discovery` (indicated by the `Well-Known` file registered in the Directory) are restricted to the operating modes to which the institution has certified
-   1. shall keep in your settings the methods for which there are still active clients
-   2. shall update the records that use non-certified methods, through bilateral treatment between the institutions involved
+   a. shall keep in your settings the methods for which there are still active clients
+   b. shall update the records that use non-certified methods, through bilateral treatment between the institutions involved
 20. shall refuse requests, for the Open Banking environment, that are outside the modes of operation to which the institution has certified its Authorization Server
 
 #### ID Token as detached signature


### PR DESCRIPTION
1. Numeração diverge da aprovada, pois havia sido baseada no HTML que
   encontra-se desatualizado
2. Incluído o texto "para o ambiente do Open Banking" no item 20, por
   que se não, iria impedir o uso do Servidor de Autorização para outras
   funcionalidades, se tivesse configuração diversa da certificada.