### PR TITLE
Versions Sync

### DIFF
--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -140,6 +140,9 @@ Os seguintes documentos referenciados são indispensáveis para a adoção das e
 [LIWP] - OIDF FAPI WG Lodging Intent Working Paper
 [LIWP]: <https://bitbucket.org/openid/fapi/src/master/Financial_API_Lodging_Intent.md
 
+[LIWP] - OIDF FAPI WG Lodging Intent Working Paper
+[LIWP]: <https://bitbucket.org/openid/fapi/src/master/Financial_API_Lodging_Intent.md
+
 [OBB-FAPI-DCR] - Open Banking Brasil Financial-grade API Dynamic Client Registration Profile 1.0
 [OBB-FAPI-DCR]: <https://openbanking-brasil.github.io/specs-seguranca/open-banking-brasil-dynamic-client-registration-1_ID2.html
 
@@ -225,44 +228,71 @@ O Servidor de Autorização *deve* suportar as disposições especificadas na cl
 
 Além disso, se o valor `response_type` `code id_token` for usado, o servidor de autorização:
 
-1. **não deveria** retornar Informação de Identificação Pessoal (PII) confidenciais no token de ID na resposta de autorização, mas se for necessário, então ele **deve** criptografar o token de ID.
+1. **não deveria** retornar Informação de Identificação Pessoal (PII) confidenciais no token de ID na resposta de autorização,
+mas se for necessário, então ele **deve** criptografar o token de ID.
 
 #### Solicitando uma "claim" **cpf**  {#cpf}
 
-Este perfil define "cpf" como uma nova `claim` padrão de acordo com cláusula 5.1 [OIDC]
+Este perfil define "cpf" como uma nova `claim` padrão de acordo com
+ cláusula 5.1 [OIDC]
 
-O número do **CPF** (Cadastro de Pessoas Físicas, [sepeˈɛfi]; português para "Registro de Pessoas Físicas") é o cadastro de pessoa física **brasileira**. Este número é atribuído pela Receita Federal **Brasileira** para brasileiros e estrangeiros residentes que, direta ou indiretamente, pagar impostos no **Brasil**.
+O número do **CPF** (Cadastro de Pessoas Físicas, [sepeˈɛfi]; português para "Registro de Pessoas Físicas")
+ é o cadastro de pessoa física **brasileira**. Este número é atribuído pela Receita Federal
+ **Brasileira** para brasileiros e estrangeiros residentes que, direta ou indiretamente,
+ pagar impostos no **Brasil**.
 
-No modelo de identidade do Open Banking Brasil, o cpf é uma string composta por números 11 caracteres de comprimento e podem começar com 0.
+No modelo de identidade do Open Banking Brasil, o cpf é uma string composta por números 11
+ caracteres de comprimento e podem começar com 0.
 
-Se a Claim **cpf** for solicitada como essencial para constar no ID token ou na resposta ao endpoint de UserInfo e na solicitação constar no parâmetro `value` com determinado **CPF** exigido, o Authorization Server **DEVE** retornar no atributo **cpf** o valor que corresponda ao da solicitação.
+Se a Claim **cpf** for solicitada como essencial para constar no ID token ou na resposta ao endpoint de UserInfo
+ e na solicitação constar no parâmetro `value` com determinado **CPF** exigido, o Authorization Server **DEVE** retornar no atributo **cpf**
+  o valor que corresponda ao da solicitação.
 
-Se a Claim **cpf** for solicitada como essencial para constar no ID Token ou na resposta no endpoint de UserInfo, o Authorization Server deve retornar no atributo **cpf** o valor com o **CPF** do usuário autenticado.
+Se a Claim **cpf** for solicitada como essencial para constar no ID Token ou na resposta no endpoint de UserInfo,
+ o Authorization Server deve retornar no atributo **cpf** o valor com o **CPF** do usuário autenticado.
 
-Se a Claim **cpf** indicada como essencial não puder ser preenchida ou não for compatível com o requisito, o Authorization Server deve tratar a solicitação como uma tentativa de autenticação com falha.
+Se a Claim **cpf** indicada como essencial não puder ser preenchida ou não for compatível com o requisito,
+ o Authorization Server deve tratar a solicitação como uma tentativa de autenticação com falha.
 
 Nome: cpf, Tipo: String, Regex: '^\d{11}$'
 
 #### Solicitando a "claim" **cnpj**  {#cnpj}
 
-Este perfil define "cnpj" como uma nova reivindicação padrão de acordo com cláusula 5.1 [OIDC]
+Este perfil define "cnpj" como uma nova reivindicação padrão de acordo
+ com cláusula 5.1 [OIDC]
 
-**CNPJ**, abreviação de Cadastro Nacional de Pessoas Jurídicas, é um número de identificação de empresas **brasileiras** emitidas pelo Ministério da Fazenda **brasileira**, **na** "Secretaria da Receita Federal" ou "Ministério da Fazenda" do Brasil. No modelo de identidade do Open Banking Brasil, pessoas físicas podem se associar a 0 ou mais CNPJs. Um CNPJ é uma string que consiste em números de 14 dígitos e pode começar com 0, os primeiros oito dígitos identificam a empresa, os quatro dígitos após a barra identificam a filial ou subsidiária ("0001" padrão para a sede), e os dois últimos são dígitos de soma de verificação. Para este perfil, o pedido de cnpj deve ser solicitado e fornecido como o número de 14 dígitos.
+**CNPJ**, abreviação de Cadastro Nacional de Pessoas Jurídicas, é um número de identificação
+ de empresas **brasileiras** emitidas pelo Ministério da Fazenda **brasileira**, **na**
+ "Secretaria da Receita Federal" ou "Ministério da Fazenda" do Brasil. No modelo de identidade do Open Banking Brasil,
+ pessoas físicas podem se associar a 0 ou mais CNPJs. Um CNPJ é uma string que consiste em números de 14 dígitos e pode começar com 0,
+ os primeiros oito dígitos identificam a empresa, os quatro dígitos após a barra identificam a filial
+ ou subsidiária ("0001" padrão para a sede), e os dois últimos são dígitos de soma de verificação.
+ Para este perfil, o pedido de cnpj deve ser solicitado e fornecido como o número de 14 dígitos.
 
-Se a Claim **cnpj** for solicitada como essencial para constar no ID Token ou na resposta ao endpoint UserInfo e na solicitação constar, no parâmetro `value`, determinado **CNPJ** exigido, o Authorization Server **DEVE** retornar no atributo **cnpj** um **conjunto** de **CNPJs** relacionado com o usuário, um dos quais deve incluir valor que corresponda ao da solicitação.
+Se a Claim **cnpj** for solicitada como essencial para constar no ID Token ou na resposta ao endpoint UserInfo e na solicitação constar,
+ no parâmetro `value`, determinado **CNPJ** exigido, o Authorization Server **DEVE** retornar no atributo **cnpj**
+ um **conjunto** de **CNPJs** relacionado com o usuário, um dos quais deve incluir valor que corresponda ao da solicitação.
 
-Se a Claim **cnpj** for solicitada como essencial para constar no ID Token ou na resposta ao endpoint UserInfo, o Authorization Server deve incluir no ID Token ou na resposta ao endpoint UserInfo um **conjunto** que inclua um elemento com o número do **CNPJ** relacionado à conta utilizada na autenticação do usuário.
+Se a Claim **cnpj** for solicitada como essencial para constar no ID Token ou na resposta ao endpoint UserInfo,
+ o Authorization Server deve incluir no ID Token ou na resposta ao endpoint UserInfo um **conjunto** que inclua um elemento
+ com o número do **CNPJ** relacionado à conta utilizada na autenticação do usuário.
 
-Se a Claim **cnpj** indicada como essencial não puder ser preenchida ou validada, o Authorization Server deve tratar a solicitação como uma tentativa de autenticação com falha.
+Se a Claim **cnpj** indicada como essencial não puder ser preenchida
+ ou validada, o Authorization Server deve tratar a solicitação como
+ uma tentativa de autenticação com falha.
 
 Nome: cnpj, Tipo: Array of Strings, Array Element Regex: '^\d{14}$'
 
 #### Solicitando o "urn:brasil:openbanking:loa2" ou "urn:brasil:openbanking:loa3" Solicitação de contexto de autenticação  {#loa}
 
+Esse perfil define "urn:brasil:openbanking:loa2" e "urn:brasil:openbanking:loa3" como
+ novas classes de "Authentication Context Request" (ACR)
+
 * **LoA2**: mecanismo de autenticação com a adoção de um único fator
 * **LoA3**: mecanismo de autenticação com múltiplos fatores de autenticação
 
-A seguinte orientação deve ser observada para o mecanismo de autenticação:
+A seguinte orientação deve ser observada para o mecanismo de autenticação das APIs do Open Banking Brasil:
+
 * De acordo com o Art. 17 da Resolução Conjunta nº 01, as instituições devem adotar  procedimentos e controles para autenticação de cliente **compatíveis com os aplicáveis ao acesso a seus canais de atendimento eletrônicos**.
 * Em observância à regulação em vigor, sugere-se que:
   * **Para a autenticação do usuário em autorizações de acessos às APIs de compartilhamento de dados (Fase 2)**, os _Authorization Servers_ **deveriam** adotar, no mínimo, método compatível com `LoA2`; e
@@ -299,7 +329,10 @@ Além disso, o cliente confidencial
 
 # Considerações de segurança  {#authserver}
 
-Os participantes devem apoiar todas as considerações de segurança especificadas na cláusula 8 [Financial-grade API Security Profile 1.0 - Parte 2: Advanced] [FAPI-1-Advanced] e o [Manual de Segurança de Banco Central do Brasil] (https://www.bcb.gov.br/estabilidadefinanceira/exibenormativo?tipo=Instru%C3%A7%C3%A3o%20Normativa%20BCB&numero=134). O ICP brasileiro emite certificados RSA x509 somente, portanto, para simplificar, a seção remove o suporte para algoritmos EC e exige que apenas algoritmos de criptografia recomendados pela IANA sejam usados.
+Os participantes devem apoiar todas as considerações de segurança especificadas na cláusula 8
+ [Financial-grade API Security Profile 1.0 - Parte 2: Advanced] [FAPI-1-Advanced] e o [Manual de Segurança de Banco Central do Brasil] (https://www.bcb.gov.br/estabilidadefinanceira/exibenormativo?tipo=Instru%C3%A7%C3%A3o%20Normativa%20BCB&numero=134).
+ O ICP Brasil emite certificados RSA x509 somente, portanto, para simplificar, a seção remove o suporte para algoritmos EC
+ e exige que apenas algoritmos de criptografia recomendados pela IANA sejam usados.
 
 ## Considerações sobre assinatura do conteúdo de mensagens (JWS) {#jws}
 
@@ -375,10 +408,6 @@ Adicionalmente:
 * Consent Resource Id deve incluir caracteres seguros para url;
 * Consent Resource Id deve ser "namespaced";
 * Consent Resource Id deve ter propriedades de um `nonce` [Nonce](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes);
-
-### Dynamic Consent Scope Example  {#consentexample}
-
-consent:urn:bancoex:C1DD33123
 
 ### Exemplo de escopo de consentimento dinâmico  {#consentid}
 

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -53,6 +53,7 @@ The key words "shall", "shall not",
 "should", "should not", "may", and
 "can" in this document are to be interpreted as described in
 [ISO Directive Part 2][ISODIR2].
+
 These key words are not used as dictionary terms such that
 any occurrence of them shall be interpreted as key words
 and are not to be interpreted with their natural language meanings.
@@ -183,8 +184,11 @@ This profile describes security and features provisions for a server and client 
 ### Introduction
 
 Open Banking Brasil has a requirement to address privacy considerations that were identified but not addressed in the [FAPI-1-Advanced] final specification without imposing additional requirements on Authorisation Servers being proposed in [FAPI-2-Baseline].
+
 Participants in this ecosystem have a need for clients to request an openid provider to confirm values of identity claims as part of an authorization request using the mechanism defined in clause 5.5.1 of [OIDC].
+
 The use of the claims parameter to request explicit claims values requires clients to ensure that they encrypt the request object to avoid information leakage. This risk is identified in clause 7.4.1 of [FAPI-1-Baseline].
+
 In addition this profile describes the specific scope, acr and client management requirements necessary to support the wider Open Banking Brasil ecosystem.
 
 As a profile of the OAuth 2.0 Authorization Framework, this document mandates the following for the Brasil Open Banking Security profile.
@@ -236,11 +240,18 @@ The **CPF** number (Cadastro de Pessoas Físicas, [sepeˈɛfi]; Portuguese for "
  is the **Brazilian** individual taxpayer registry identification. This number is attributed by
  the **Brazilian** Federal Revenue to Brazilians and resident aliens who, directly or indirectly,
   pay taxes in **Brazil**.
+
 In the Brasil Open Banking identity model, the cpf is a string consisting of numbers that is 11
 characters long and may start with a 0.
+
 If the cpf Claim is requested as an Essential Claim for the ID Token or UserInfo response with a
-values parameter requesting a specific cpf value, the Authorization Server MUST return a cpf Claim Value
-that matches the requested value. If this is an Essential Claim and the requirement cannot be met,
+ values parameter requesting a specific cpf value, the Authorization Server MUST return a cpf Claim Value
+that matches the requested value.
+
+If the cpf Claim is requested as an Essential Claim for the ID Token or UserInfo response,
+ the Authorization Server MUST return a cpf Claim Value with the authenticated user cpf value.
+
+If this is an Essential Claim and the requirement cannot be met or is not compatible with the one requested,
  then the Authorization Server MUST treat that outcome as a failed authentication attempt.
 
 Name: cpf, Type: String, Regex: '^\d{11}$'
@@ -255,13 +266,19 @@ This profile defines "cnpj" as a new standard claim as per
  Portuguese "Secretaria da Receita Federal" or "Ministério da Fazenda". In the Brasil Open Banking identity model,
  individuals can associated with 0 or more CNPJs. A CNPJ is a string consisting of numbers that is 14 digits long and may start with a 0,
  the first eight digits identify the company, the four digits after the slash identify the branch or
-  subsidiary ("0001" defaults to the headquarters), and the last two are checksum digits.
-   For this profile, the cnpj claim must be requested and supplied as the 14 digit number.
+ subsidiary ("0001" defaults to the headquarters), and the last two are checksum digits.
+ For this profile, the cnpj claim must be requested and supplied as the 14 digit number.
 
 If the cnpj Claim is requested as an Essential Claim for the ID Token or UserInfo response with a
 values parameter requesting a specific cnpj value, the Authorization Server MUST return a cnpj
-Claim Value that contains a **set** of CNPJs one of which must match the requested value. If this
- is an Essential Claim and the requirement cannot be met, then the Authorization Server MUST treat
+Claim Value that contains a **set** of CNPJs one of which must match the requested value.
+
+If the cnpj Claim is requested as an Essential Claim for the ID Token or UserInfo
+ the Authorization Server MUST return a cnpj Claim Value that contains a **set** of CNPJs one of which must
+ match a CNPJ belonging to the authenticated user's account.
+
+If this is an Essential Claim and the requirement cannot be met,
+ then the Authorization Server MUST treat
  that outcome as a failed authentication attempt.
 
 Name: cnpj, Type: Array of Strings, Array Element Regex: '^\d{14}$'
@@ -269,7 +286,7 @@ Name: cnpj, Type: Array of Strings, Array Element Regex: '^\d{14}$'
 #### Requesting the "urn:brasil:openbanking:loa2" or "urn:brasil:openbanking:loa3" Authentication Context Request
 
 This profile defines "urn:brasil:openbanking:loa2" and "urn:brasil:openbanking:loa3" as
- new Authentication Context Request classes.
+ new Authentication Context Request (ACR) classes.
 
 * **LoA2:** Authentication performed using single factor;
 * **LoA3:** Authentication performed using multi factor (MFA)


### PR DESCRIPTION
- Equalizada numeração de linhas para facilitar comparação
- Link para a FAPI-2 Advanced disponível só em Inglês
- Em inglês não pedia que retornasse o CPF da pessoa autenticada
- Em portugues nâo incluia texto informando que o perfil definia duas novas classes de ACR
- "ICP Brasileiro" ao invés de "ICP Brasil"
- Texto em inglês duplicado na versão portugues
