### PR TITLE
Campo OU - Alteração em 7.1 e 9.3.1

### DIFF
--- a/open-banking-brasil-dynamic-client-registration-1_ID2-ptbr.html
+++ b/open-banking-brasil-dynamic-client-registration-1_ID2-ptbr.html
@@ -1547,13 +1547,15 @@ li > p:last-of-type {
 </li>
           <li id="section-7.1-3.12">se for compat&#237;vel com o mecanismo de autentica&#231;&#227;o do cliente <code>tls_client_auth</code>, conforme definido em <a href="https://tools.ietf.org/html/rfc8705">RFC8705</a>, somente deve aceitar <code>tls_client_auth_subject_dn</code> como uma indica&#231;&#227;o do valor do atributo <em>subject</em> do certificado, conforme definido na cl&#225;usula 2.1.2 <a href="https://tools.ietf.org/html/rfc8705">RFC8705</a>;<a href="#section-7.1-3.12" class="pilcrow">¶</a>
 </li>
-          <li id="section-7.1-3.13">Os valores dos campos <em>UID</em> e <em>OU</em> do certificado devem coincidir com os enviados no SSA. O campo <em>OU</em> deve conter o valor do campo <em>org_id</em> do SSA e campo <em>UID</em> deve conter o valor do campo <em>software_id</em> do SSA.<a href="#section-7.1-3.13" class="pilcrow">¶</a>
+          <li id="section-7.1-3.13">O valor do campo <em>UID</em> do certificado deve coincidir com o enviado no SSA, onde o campo <em>UID</em> deve conter o valor do campo <em>software_id</em> do SSA.<a href="#section-7.1-3.13" class="pilcrow">¶</a>
 </li>
-          <li id="section-7.1-3.14">deve, durante o processo de handshake TLS, usar a regra <code>distinguishedNameMatch</code> para comparar os valores DN conforme definido na <a href="https://www.rfc-editor.org/rfc/rfc4517">RFC4517</a>.<a href="#section-7.1-3.14" class="pilcrow">¶</a>
+          <li id="section-7.1-3.14">O valor do campo <em>organizationIdentifier</em> do certificado deve conter o prefixo correspondente ao Registration Reference <em>OFBBR-</em> seguido do valor do campo <em>org_id</em> do SSA. <br/> Para certificados emitidos até 31 de Agosto de 2022: o valor do campo <em>OU</em> do certificado deve conter o valor do campo <em>org_id</em> do SSA.<a href="#section-7.1-3.14" class="pilcrow">¶</a>
 </li>
-          <li id="section-7.1-3.15">deve garantir a integridade do estoque de consentimentos ativos, mesmo ap&#243;s eventuais mudan&#231;as sist&#234;micas, para que ta&#237;s altera&#231;&#245;es sejam transparentes para as institui&#231;&#245;es receptora de dados (TPP).<a href="#section-7.1-3.15" class="pilcrow">¶</a>
+          <li id="section-7.1-3.15">deve, durante o processo de handshake TLS, usar a regra <code>distinguishedNameMatch</code> para comparar os valores DN conforme definido na <a href="https://www.rfc-editor.org/rfc/rfc4517">RFC4517</a>.<a href="#section-7.1-3.15" class="pilcrow">¶</a>
 </li>
-          <li id="section-7.1-3.16">deve realizar recertifica&#231;&#227;o FAPI e DCR da OIDF ap&#243;s eventuais mudan&#231;as sist&#234;micas.<a href="#section-7.1-3.16" class="pilcrow">¶</a>
+          <li id="section-7.1-3.16">deve garantir a integridade do estoque de consentimentos ativos, mesmo ap&#243;s eventuais mudan&#231;as sist&#234;micas, para que ta&#237;s altera&#231;&#245;es sejam transparentes para as institui&#231;&#245;es receptora de dados (TPP).<a href="#section-7.1-3.16" class="pilcrow">¶</a>
+</li>
+          <li id="section-7.1-3.17">deve realizar recertifica&#231;&#227;o FAPI e DCR da OIDF ap&#243;s eventuais mudan&#231;as sist&#234;micas.<a href="#section-7.1-3.17" class="pilcrow">¶</a>
 </li>
         </ol>
 <p id="section-7.1-4">Estas disposi&#231;&#245;es aplicam-se igualmente ao processamento de pedidos <a href="https://tools.ietf.org/html/rfc7591">RFC7591</a>, <a href="https://tools.ietf.org/html/rfc7592">RFC7592</a> e <a href="https://openid.net/specs/openid-connect-registration-1_0.html">OpenID Registration</a><a href="#section-7.1-4" class="pilcrow">¶</a></p>
@@ -1981,15 +1983,17 @@ Para estender as <a href="https://tools.ietf.org/html/rfc7591">RFC7591</a> e <a 
 <a href="#section-9.3.1" class="section-number selfRef">9.3.1. </a><a href="#name-registro-de-cliente-post-re" class="section-name selfRef">Registro de cliente - POST /register</a>
           </h4>
 <ol start="1" type="1" class="compact type-1" id="section-9.3.1-1">
-<li id="section-9.3.1-1.1">validar que o certificado apresentado pela aplica&#231;&#227;o cliente &#233; subordinado &#224;s cadeias do ICP-Brasil definidas no Padr&#227;o de Certificados do Open Finance Brasil;<a href="#section-9.3.1-1.1" class="pilcrow">¶</a>
+            <li id="section-9.3.1-1.1">validar que o certificado apresentado pela aplica&#231;&#227;o cliente &#233; subordinado &#224;s cadeias do ICP-Brasil definidas no Padr&#227;o de Certificados do Open Finance Brasil;<a href="#section-9.3.1-1.1" class="pilcrow">¶</a>
 </li>
-            <li id="section-9.3.1-1.2">assegurar que a assinatura do <em>software_statement</em> apresentado pela aplica&#231;&#227;o cliente durante o registro tenha sido feita pelo Diret&#243;rio de Participantes atrav&#233;s das chaves p&#250;blicas descritas na se&#231;&#227;o anterior;<a href="#section-9.3.1-1.2" class="pilcrow">¶</a>
+            <li id="section-9.3.1-1.2">enquanto houver a necessidade do período de convivência (mencionado no tópico 7.1) deve ser implementado a validação para ambos os casos: certificados que possuem o valor <em>org_id</em> no campo <em>organizationUnitName</em> (<em>OU</em>) e certificados que possuem o valor <em>org_id</em> no campo <em>organizationIdentifier</em>.<a href="#section-9.3.1-1.2" class="pilcrow">¶</a>
+</li>  
+            <li id="section-9.3.1-1.3">assegurar que a assinatura do <em>software_statement</em> apresentado pela aplica&#231;&#227;o cliente durante o registro tenha sido feita pelo Diret&#243;rio de Participantes atrav&#233;s das chaves p&#250;blicas descritas na se&#231;&#227;o anterior;<a href="#section-9.3.1-1.3" class="pilcrow">¶</a>
 </li>
-            <li id="section-9.3.1-1.3">assegurar que o <em>software_statement</em> apresentado pela aplica&#231;&#227;o cliente durante o registro corresponda &#224; mesma institui&#231;&#227;o do certificado de cliente apresentado, validando-o atrav&#233;s dos atributos que trazem <code>organization_id</code> no certificado X.509.<a href="#section-9.3.1-1.3" class="pilcrow">¶</a>
+            <li id="section-9.3.1-1.4">assegurar que o <em>software_statement</em> apresentado pela aplica&#231;&#227;o cliente durante o registro corresponda &#224; mesma institui&#231;&#227;o do certificado de cliente apresentado, validando-o atrav&#233;s dos atributos que trazem <code>organization_id</code> no certificado X.509.<a href="#section-9.3.1-1.4" class="pilcrow">¶</a>
 </li>
-            <li id="section-9.3.1-1.4">não devem ser permitidos múltiplos cadastros DCR para o mesmo Software Statement , de forma que em caso de tentativa de novo registro para um Software Statement já cadastrado, deve se utilizar o procedimento de Error Response definido no item 3.2.2 da <a href="https://tools.ietf.org/html/rfc7591">RFC7591</a>.<a href="#section-9.3.1-1.4" class="pilcrow">¶</a>
+            <li id="section-9.3.1-1.5">não devem ser permitidos múltiplos cadastros DCR para o mesmo Software Statement , de forma que em caso de tentativa de novo registro para um Software Statement já cadastrado, deve se utilizar o procedimento de Error Response definido no item 3.2.2 da <a href="https://tools.ietf.org/html/rfc7591">RFC7591</a>.<a href="#section-9.3.1-1.5" class="pilcrow">¶</a>
 </li>
-            <li id="section-9.3.1-1.5">emitir, na resposta do registro, um <code>registration_access_token</code> para ser usado como token de autenticação nas opera&#231;&#245;es de manuten&#231;&#227;o da aplica&#231;&#227;o cliente registrada, seguindo as especifica&#231;&#245;es descritas na <a href="https://tools.ietf.org/html/rfc7592">RFC7592</a>.<a href="#section-9.3.1-1.5" class="pilcrow">¶</a>
+            <li id="section-9.3.1-1.6">emitir, na resposta do registro, um <code>registration_access_token</code> para ser usado como token de autenticação nas opera&#231;&#245;es de manuten&#231;&#227;o da aplica&#231;&#227;o cliente registrada, seguindo as especifica&#231;&#245;es descritas na <a href="https://tools.ietf.org/html/rfc7592">RFC7592</a>.<a href="#section-9.3.1-1.6" class="pilcrow">¶</a>
 </li>		
           </ol>
 </section>


### PR DESCRIPTION
Novo texto: 
[...]
          <li id="section-7.1-3.13">O valor do campo <em>UID</em> do certificado deve coincidir com o enviado no SSA, onde o campo <em>UID</em> deve conter o valor do campo <em>software_id</em> do SSA.<a href="#section-7.1-3.13" class="pilcrow">¶</a>
</li>
          <li id="section-7.1-3.14">O valor do campo <em>organizationIdentifier</em> do certificado deve conter o prefixo correspondente ao Registration Reference <em>OFBBR-</em> seguido do valor do campo <em>org_id</em> do SSA. Para certificados emitidos até 31 de Agosto de 2022: o valor do campo <em>OU</em> do certificado deve conter o valor do campo <em>org_id</em> do SSA.<a href="#section-7.1-3.14" class="pilcrow">¶</a>
</li>
          <li id="section-7.1-3.15">deve, durante o processo de handshake TLS, usar a regra <code>distinguishedNameMatch</code> para comparar os valores DN conforme definido na <a href="https://www.rfc-editor.org/rfc/rfc4517">RFC4517</a>.<a href="#section-7.1-3.15" class="pilcrow">¶</a>
</li>
          <li id="section-7.1-3.16">deve garantir a integridade do estoque de consentimentos ativos, mesmo ap&#243;s eventuais mudan&#231;as sist&#234;micas, para que ta&#237;s altera&#231;&#245;es sejam transparentes para as institui&#231;&#245;es receptora de dados (TPP).<a href="#section-7.1-3.16" class="pilcrow">¶</a>
</li>
          <li id="section-7.1-3.17">deve realizar recertifica&#231;&#227;o FAPI e DCR da OIDF ap&#243;s eventuais mudan&#231;as sist&#234;micas.<a href="#section-7.1-3.17" class="pilcrow">¶</a>
</li>


[...]

<a href="#section-9.3.1" class="section-number selfRef">9.3.1. </a><a href="#name-registro-de-cliente-post-re" class="section-name selfRef">Registro de cliente - POST /register</a>
          </h4>
<ol start="1" type="1" class="compact type-1" id="section-9.3.1-1">
            <li id="section-9.3.1-1.1">validar que o certificado apresentado pela aplica&#231;&#227;o cliente &#233; subordinado &#224;s cadeias do ICP-Brasil definidas no Padr&#227;o de Certificados do Open Finance Brasil;<a href="#section-9.3.1-1.1" class="pilcrow">¶</a>
</li>
            <li id="section-9.3.1-1.2">enquanto houver a necessidade do período de convivência (mencionado no tópico 7.1) deve ser implementado a validação para ambos os casos: certificados que possuem o valor <em>org_id</em> no campo <em>organizationUnitName</em> (<em>OU</em>) e certificados que possuem o valor <em>org_id</em> no campo <em>organizationIdentifier</em>.<a href="#section-9.3.1-1.2" class="pilcrow">¶</a>
</li>
            <li id="section-9.3.1-1.3">assegurar que a assinatura do <em>software_statement</em> apresentado pela aplica&#231;&#227;o cliente durante o registro tenha sido feita pelo Diret&#243;rio de Participantes atrav&#233;s das chaves p&#250;blicas descritas na se&#231;&#227;o anterior;<a href="#section-9.3.1-1.3" class="pilcrow">¶</a>
</li>
            <li id="section-9.3.1-1.4">assegurar que o <em>software_statement</em> apresentado pela aplica&#231;&#227;o cliente durante o registro corresponda &#224; mesma institui&#231;&#227;o do certificado de cliente apresentado, validando-o atrav&#233;s dos atributos que trazem <code>organization_id</code> no certificado X.509.<a href="#section-9.3.1-1.4" class="pilcrow">¶</a>
</li>
            <li id="section-9.3.1-1.5">não devem ser permitidos múltiplos cadastros DCR para o mesmo Software Statement , de forma que em caso de tentativa de novo registro para um Software Statement já cadastrado, deve se utilizar o procedimento de Error Response definido no item 3.2.2 da <a href="https://tools.ietf.org/html/rfc7591">RFC7591</a>.<a href="#section-9.3.1-1.5" class="pilcrow">¶</a>
</li>
            <li id="section-9.3.1-1.6">emitir, na resposta do registro, um <code>registration_access_token</code> para ser usado como token de autenticação nas opera&#231;&#245;es de manuten&#231;&#227;o da aplica&#231;&#227;o cliente registrada, seguindo as especifica&#231;&#245;es descritas na <a href="https://tools.ietf.org/html/rfc7592">RFC7592</a>.<a href="#section-9.3.1-1.6" class="pilcrow">¶</a>
</li>   
          </ol>