### PR TITLE
Proibição do campo OU - Certificados - Ajustes md ptbr

### DIFF
--- a/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
+++ b/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
@@ -150,7 +150,8 @@ O Certificado Cliente deve ser emitido através de cadeia V10, e deve obrigatori
 * **organizationName (OID 2.5.4.10):** Razão Social
 * **stateOrProvinceName (OID 2.5.4.8):** Unidade da federação do endereço físico do titular do certificado
 * **localityName (OID 2.5.4.7):** Cidade do endereço físico do titular
-* **organizationIdentifier (OID 2.5.4.97):** Código de Participante associado ao CNPJ listado no Serviço de Diretório do Open Finance Brasil. *Para certificados emitidos até 31 Agosto de 2022: **organizationalUnitName (OID 2.5.4.11):** Código de Participante associado ao CNPJ listado no Serviço de Diretório do Open Finance Brasil
+* **organizationIdentifier (OID 2.5.4.97):** Código de Participante associado ao CNPJ listado no Serviço de Diretório do Open Finance Brasil. 
+Para certificados emitidos até 31 Agosto de 2022: **organizationalUnitName (OID 2.5.4.11):** Código de Participante associado ao CNPJ listado no Serviço de Diretório do Open Finance Brasil
 * **UID (OID 0.9.2342.19200300.100.1.1):** Software Statement ID gerado pelo Diretório do Open Finance Brasil
 * **commonName (OID 2.5.4.3):** FQDN ou Wildcard
 
@@ -179,9 +180,10 @@ O Certificado de Assinatura deve ser emitido através de cadeia V5, e deve obrig
 * **UID (OID 0.9.2342.19200300.100.1.1):**  Código de Participante associado ao CNPJ listado no Serviço de Diretório do Open Finance Brasil
 * **countryName (OID 2.5.4.6):** BR
 * **organizationName (OID 2.5.4.10):** ICP-Brasil
-* **organizationIdentifier (OID 2.5.4.97):** Nome da Autoridade Certificadora. *Para certificados emitidos até 31 Agosto de 2022: **organizationalUnitName (OID 2.5.4.11):** Nome da Autoridade Certificadora
-* **organizationIdentifier (OID 2.5.4.97):** CNPJ da Autoridade de Registro. *Para certificados emitidos até 31 Agosto de 2022: **organizationalUnitName (OID 2.5.4.11):** CNPJ da Autoridade de Registro
-* **organizationIdentifier (OID 2.5.4.97):** Tipo de identificação utilizada (presencial, videoconferência ou certificado digital). *Para certificados emitidos até 31 Agosto de 2022: **organizationalUnitName (OID 2.5.4.11):** Tipo de identificação utilizada (presencial, videoconferência ou certificado digital)
+* **organizationIdentifier (OID 2.5.4.97):** Nome da Autoridade Certificadora. *Para certificados emitidos até 31 Agosto de 2022:
+* **organizationalUnitName (OID 2.5.4.11):** Nome da Autoridade Certificadora
+* **organizationalUnitName (OID 2.5.4.11):** CNPJ da Autoridade de Registro
+* **organizationalUnitName (OID 2.5.4.11):** Tipo de identificação utilizada (presencial, videoconferência ou certificado digital)
 * **commonName (OID 2.5.4.3):** Nome da Razão Social
 
 **Certificate Extensions**
@@ -285,6 +287,9 @@ DNS = <FQDN|Wildcard>
 ## Modelo de Configuração de Certificado Cliente - OpenSSL *Para certificados emitidos após 31 Agosto 2022 {#ModeloConfiguracaoCertificadoClienteOpenSSL}
 
 ```
+
+oid_section = OIDs
+
 [req]
 default_bits = 2048
 default_md = sha256
@@ -293,6 +298,9 @@ prompt = no
 string_mask = nombstr
 distinguished_name = client_distinguished_name
 req_extensions = req_cert_extensions
+
+[ OIDs ]
+organizationIdentifier = 2.5.4.97
 
 [ client_distinguished_name ]
 businessCategory = <tipo de entidade>
@@ -316,7 +324,7 @@ extendedKeyUsage = clientAuth
 DNS = <FQDN|Wildcard>
 ```
 
-## Modelo de Configuração de Certificado de Assinatura - OpenSSL *Para certificados emitidos até 31 Agosto 2022 {#ModeloConfiguracaoCertificadoAssinaturaOpenSSL}
+## Modelo de Configuração de Certificado de Assinatura {#ModeloConfiguracaoCertificadoAssinaturaOpenSSL}
 
 ```
 [req]
@@ -335,39 +343,6 @@ organizationName = ICP-Brasil
 0.organizationalUnitName = <Autoridade Certificadora>
 1.organizationalUnitName = <CNPJ da Autoridade Registradora>
 2.organizationalUnitName = <Tipo de validação>
-commonName = <Razão Social>
-
-[ req_cert_extensions ]
-basicConstraints = CA:FALSE
-subjectAltName = @alt_name
-keyUsage = critical,digitalSignature,nonRepudiation
-
-[ alt_name ]
-otherName.0 = 2.16.76.1.3.2;PRINTABLESTRING:<Nome da pessoal responsável pela entidade>#CNPJ
-otherName.1 = 2.16.76.1.3.3;PRINTABLESTRING:<CNPJ>
-otherName.2 = 2.16.76.1.3.4;PRINTABLESTRING:<CPF/PIS/RF da Pessoa responsável>
-otherName.3 = 2.16.76.1.3.7;PRINTABLESTRING:<Número de INSS>
-```
-
-## Modelo de Configuração de Certificado de Assinatura - OpenSSL *Para certificados emitidos após 31 Agosto 2022 {#ModeloConfiguracaoCertificadoAssinaturaOpenSSL}
-
-```
-[req]
-default_bits = 2048
-default_md = sha256
-encrypt_key = yes
-prompt = no
-string_mask = nombstr
-distinguished_name = client_distinguished_name
-req_extensions = req_cert_extensions
-
-[ client_distinguished_name ]
-UID = <Código de Participante>
-countryName = BR
-organizationName = ICP-Brasil
-0.organizationIdentifier = OFBBR-<Autoridade Certificadora>
-1.organizationIdentifier = OFBBR-<CNPJ da Autoridade Registradora>
-2.organizationIdentifier = OFBBR-<Tipo de validação>
 commonName = <Razão Social>
 
 [ req_cert_extensions ]

--- a/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
+++ b/open-banking-brasil-certificate-standards-1_ID1-ptbr.md
@@ -180,7 +180,6 @@ O Certificado de Assinatura deve ser emitido através de cadeia V5, e deve obrig
 * **UID (OID 0.9.2342.19200300.100.1.1):**  Código de Participante associado ao CNPJ listado no Serviço de Diretório do Open Finance Brasil
 * **countryName (OID 2.5.4.6):** BR
 * **organizationName (OID 2.5.4.10):** ICP-Brasil
-* **organizationIdentifier (OID 2.5.4.97):** Nome da Autoridade Certificadora. *Para certificados emitidos até 31 Agosto de 2022:
 * **organizationalUnitName (OID 2.5.4.11):** Nome da Autoridade Certificadora
 * **organizationalUnitName (OID 2.5.4.11):** CNPJ da Autoridade de Registro
 * **organizationalUnitName (OID 2.5.4.11):** Tipo de identificação utilizada (presencial, videoconferência ou certificado digital)


### PR DESCRIPTION
Removido as informações inseridas sobre o campo organizationIdentifier no certificado de assinatura, pois isso nao será  necessário - sessões [5.2.3.1.] e [8.2]. 

Adicionado novas informações para o modelo de geração de .csr  para certificados de cliente - sessão 8.1.2

