### PR TITLE
Proibição do campo OU - Certificados - Ajustes html ptbr

### DIFF
--- a/open-banking-brasil-certificate-standards-1_ID1-ptbr.html
+++ b/open-banking-brasil-certificate-standards-1_ID1-ptbr.html
@@ -1417,7 +1417,7 @@ tr:nth-child(2n+1) > td {
 </li>
 <li id="section-5.2.2.1-4.8">
   <p id="section-5.2.2.1-4.8.1">
-    <strong>organizationIdentifier (OID 2.5.4.97):</strong> Código de Participante associado ao CNPJ listado no Serviço de Diretório do Open Finance Brasil. *Para certificados emitidos até 31 Agosto de 2022: <strong>organizationalUnitName (OID 2.5.4.11):</strong> Código de Participante associado ao CNPJ listado no Serviço de Diretório do Open Finance Brasil<a href="#section-5.2.2.1-4.8.1" class="pilcrow">¶</a>
+    <strong>organizationIdentifier (OID 2.5.4.97):</strong> Código de Participante associado ao CNPJ listado no Serviço de Diretório do Open Finance Brasil. <br/> *Para certificados emitidos até 31 Agosto de 2022: <strong>organizationalUnitName (OID 2.5.4.11):</strong> Código de Participante associado ao CNPJ listado no Serviço de Diretório do Open Finance Brasil<a href="#section-5.2.2.1-4.8.1" class="pilcrow">¶</a>
   </p>
 </li>
 <li id="section-5.2.2.1-4.9">
@@ -1480,17 +1480,17 @@ tr:nth-child(2n+1) > td {
   
 <li id="section-5.2.3.1-4.4">
   <p id="section-5.2.3.1-4.4.1">
-    <strong>organizationIdentifier (OID 2.5.4.97): Nome da Autoridade Certificadora</strong>. *Para certificados emitidos até 31 Agosto de 2022: <strong>organizationalUnitName (OID 2.5.4.11):</strong> Nome da Autoridade Certificadora<a href="#section-5.2.3.1-4.4.1" class="pilcrow">¶</a>
+    <strong>organizationalUnitName (OID 2.5.4.11):</strong> Nome da Autoridade Certificadora<a href="#section-5.2.3.1-4.4.1" class="pilcrow">¶</a>
   </p>
 </li>
 <li id="section-5.2.3.1-4.5">
   <p id="section-5.2.3.1-4.5.1">
-    <strong>organizationalUnitName (OID 2.5.4.11):</strong> CNPJ da Autoridade de Registro. *Para certificados emitidos até 31 Agosto de 2022: <strong>organizationalUnitName (OID 2.5.4.11):</strong> CNPJ da Autoridade de Registro<a href="#section-5.2.3.1-4.5.1" class="pilcrow">¶</a>
+    <strong>organizationalUnitName (OID 2.5.4.11):</strong> CNPJ da Autoridade de Registro<a href="#section-5.2.3.1-4.5.1" class="pilcrow">¶</a>
   </p>
 </li>
 <li id="section-5.2.3.1-4.6">
   <p id="section-5.2.3.1-4.6.1">
-    <strong>organizationalUnitName (OID 2.5.4.11):</strong> Tipo de identificação utilizada (presencial, videoconferência ou certificado digital). *Para certificados emitidos até 31 Agosto de 2022: <strong>organizationalUnitName (OID 2.5.4.11):</strong> Tipo de identifica&#231;&#227;o utilizada (presencial, videoconfer&#234;ncia ou certificado digital)<a href="#section-5.2.3.1-4.6.1" class="pilcrow">¶</a>
+    <strong>organizationalUnitName (OID 2.5.4.11):</strong> Tipo de identificação utilizada (presencial, videoconferência ou certificado digital). <a href="#section-5.2.3.1-4.6.1" class="pilcrow">¶</a>
   </p>
 </li>
   
@@ -1688,6 +1688,8 @@ tr:nth-child(2n+1) > td {
     </h3>
     <div class="artwork art-text alignLeft" id="section-8.1-2">
       <pre>[req]
+      oid_section = OIDs
+        
       default_bits = 2048
       default_md = sha256
       encrypt_key = yes
@@ -1695,6 +1697,9 @@ tr:nth-child(2n+1) > td {
       string_mask = nombstr
       distinguished_name = client_distinguished_name
       req_extensions = req_cert_extensions
+
+      [ OIDs ]
+      organizationIdentifier = 2.5.4.97
 
       [ client_distinguished_name ]
       businessCategory = &lt;tipo de entidade&gt;
@@ -1725,9 +1730,9 @@ tr:nth-child(2n+1) > td {
   <section id="section-8.2">
     
     <h3 id="name-modelo-de-configura231227o-d">
-      <a href="#section-8.2-1" class="section-number selfRef">8.2.1 </a>
+      <a href="#section-8.2" class="section-number selfRef">8.2 </a>
       <a href="#name-modelo-de-configura231227o-d" class="section-name selfRef">
-        Modelo de Configura&#231;&#227;o de Certificado de Assinatura - OpenSSL *Para certificados emitidos até 31 Agosto 2022
+        Modelo de Configura&#231;&#227;o de Certificado de Assinatura - OpenSSL 
       </a>
     </h3>
     <div class="artwork art-text alignLeft" id="section-8.2-1">
@@ -1762,44 +1767,7 @@ tr:nth-child(2n+1) > td {
       </pre><a href="#section-8.2-1" class="pilcrow">¶</a>
     </div>
     
-    <h3 id="name-modelo-de-configura231227o-d-2">
-      <a href="#section-8.2-2" class="section-number selfRef">8.2.2 </a>
-      <a href="#name-modelo-de-configura231227o-d-2" class="section-name selfRef">
-        Modelo de Configura&#231;&#227;o de Certificado de Assinatura - OpenSSL *Para certificados emitidos após 31 Agosto 2022
-      </a>
-    </h3>
-    <div class="artwork art-text alignLeft" id="section-8.2-2">
-      <pre>[req]
-      default_bits = 2048
-      default_md = sha256
-      encrypt_key = yes
-      prompt = no
-      string_mask = nombstr
-      distinguished_name = client_distinguished_name
-      req_extensions = req_cert_extensions
-
-      [ client_distinguished_name ]
-      UID = &lt;Código de Participante&gt;
-      countryName = BR
-      organizationName = ICP-Brasil
-      0.organizationIdentifier = OFBBR-&lt;Autoridade Certificadora&gt;
-      1.organizationIdentifier = OFBBR-&lt;CNPJ da Autoridade Registradora&gt;
-      2.organizationIdentifier = OFBBR-&lt;Tipo de validação&gt;
-      commonName = &lt;Razão Social&gt;
-
-      [ req_cert_extensions ]
-      basicConstraints = CA:FALSE
-      subjectAltName = @alt_name
-      keyUsage = critical,digitalSignature,nonRepudiation
-
-      [ alt_name ]
-      otherName.0 = 2.16.76.1.3.2;PRINTABLESTRING:&lt;Nome da pessoal responsável pela entidade&gt;#CNPJ
-      otherName.1 = 2.16.76.1.3.3;PRINTABLESTRING:&lt;CNPJ&gt;
-      otherName.2 = 2.16.76.1.3.4;PRINTABLESTRING:&lt;CPF/PIS/RF da Pessoa responsável&gt;
-      otherName.3 = 2.16.76.1.3.7;PRINTABLESTRING:&lt;Número de INSS&gt;
-      </pre><a href="#section-8.2-2" class="pilcrow">¶</a>
-    </div>
-    
+   
   </section>
 </div>
 <div id="tabela-com-endpoints-vs-tipo-de-certificado-e-mtls">


### PR DESCRIPTION
Removido as informações inseridas sobre o campo organizationIdentifier no certificado de assinatura, pois isso nao será necessário - sessões [5.2.3.1.] e [8.2].

Adicionado novas informações para o modelo de geração de .csr para certificados de cliente - sessão 8.1.2