### PR TITLE
Padronização de request_uri html/ptbr

### DIFF
--- a/open-banking-brasil-financial-api-1_ID3-ptbr.html
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.html
@@ -1532,6 +1532,31 @@ li > p:last-of-type {
 </li>
             <li id="section-5.2.2-3.17">n&#227;o deve permitir o recurso de rota&#231;&#227;o de <code>refresh tokens</code>.<a href="#section-5.2.2-3.17" class="pilcrow">¶</a>
 </li>
+<li id="section-5.2.2-3.18">deve garantir que em caso de compartilhamento do Servidor de Autorização para outros serviços, além do Open Finance, não divulgue e/ou possibilite o uso de métodos não certificados no ambiente do Open Finance.<a href="#section-5.2.2-3.18" class="pilcrow">¶</a>
+</li>
+<li id="section-5.2.2-3.19">deve garantir que as configurações divulgadas aos demais participantes através do `OpenID Discovery` (indicado pelo arquivo de `Well-Known` cadastrado no Diretório) sejam restritos aos modos de operação aos quais a instituição se certificou.<a href="#section-5.2.2-3.19" class="pilcrow">¶</a>
+</li>
+
+
+<ul class="compact">
+
+<li class="compact" id="section-5.2.2-3.19-1.1">
+                <strong>deve manter em suas configurações os métodos para os quais ainda hajam clientes ativos;</strong><a href="#section-5.2.2-3.19-1.1" class="pilcrow">¶</a>
+</li>
+              <li class="compact" id="5.2.2-3.19-1.2">
+                <strong>deve atualizar os cadastros que utilizem métodos não certificados, através de tratamento bilateral entre as instituições envolvidas.</strong><a href="#section-5.2.2.4-1.2" class="pilcrow">¶</a>
+</li>
+            </ul>
+
+<li id="section-5.2.2-3.20">deve recusar requisições, para o ambiente do Open Finance, que estejam fora dos modos de operação ao qual a instituição certificou seu Servidor de Autorização.<a href="#section-5.2.2-3.20" class="pilcrow">¶</a>
+</li>
+<li id="section-5.2.2-3.21">deve recusar requisições de autenticação que incluam um id_token_hint, visto que o id_token em posse do requisitante pode conter Informação de Identificação Pessoal, que poderia ser enviada descriptografada pelo cliente público.<a href="#section-5.2.2-3.21" class="pilcrow">¶</a>
+</li>
+<li id="section-5.2.2-3.22">o tempo mínimo de expiração do <code>request_uri</code> deve ser de 60 segundos.<a href="#section-5.2.2-3.22" class="pilcrow">¶</a>
+</li>  
+  
+  
+  
           </ol>
 <div id="detached">
 <section id="section-5.2.2.1">


### PR DESCRIPTION
Adição das informações no item 5.2.2:

18. deve garantir que em caso de compartilhamento do Servidor de Autorização para outros serviços, além do Open Finance, não divulgue e/ou possibilite o uso de métodos não certificados no ambiente do Open Finance;
19. deve garantir que as configurações divulgadas aos demais participantes através do `OpenID Discovery` (indicado pelo arquivo de `Well-Known` cadastrado no Diretório) sejam restritos aos modos de operação aos quais a instituição se certificou;
    1. deve manter em suas configurações os métodos para os quais ainda hajam clientes ativos;
    2. deve atualizar os cadastros que utilizem métodos não certificados, através de tratamento bilateral entre as instituições envolvidas.
20. deve recusar requisições, para o ambiente do Open Finance, que estejam fora dos modos de operação ao qual a instituição certificou seu Servidor de Autorização;
21. deve recusar requisições de autenticação que incluam um id_token_hint, visto que o id_token em posse do requisitante pode conter Informação de Identificação Pessoal, que poderia ser enviada descriptografada pelo cliente público.
22. o tempo mínimo de expiração do request_uri deve ser de 60 segundos