### PR TITLE
Padronização de request_uri html/eng

### DIFF
--- a/open-banking-brasil-financial-api-1_ID3.html
+++ b/open-banking-brasil-financial-api-1_ID3.html
@@ -1523,6 +1523,31 @@ In addition this profile describes the specific scope, acr and client management
 </li>
             <li id="section-5.2.2-3.17">shall not allow <code>refresh tokens</code> rotation feature.<a href="#section-5.2.2-3.17" class="pilcrow">¶</a>
 </li>
+  
+  
+<li id="section-5.2.2-3.18">shall ensure that, in case of sharing the Authorization Server for other services, in addition to Open Finance, it does not disclose and/or allow the use of non-certified methods in the Open Finance environment.<a href="#section-5.2.2-3.18" class="pilcrow">¶</a>
+</li>
+<li id="section-5.2.2-3.19">shall ensure that the settings disclosed to other participants through `OpenID Discovery` (indicated by the `Well-Known` file registered in the Directory) are restricted to the operating modes to which the institution has certified.<a href="#section-5.2.2-3.19" class="pilcrow">¶</a>
+</li>
+
+
+<ul class="compact">
+
+<li class="compact" id="section-5.2.2-3.19-1.1">
+                <strong>shall keep in your settings the methods for which there are still active clients;</strong><a href="#section-5.2.2-3.19-1.1" class="pilcrow">¶</a>
+</li>
+              <li class="compact" id="5.2.2-3.19-1.2">
+                <strong>shall update the records that use non-certified methods, through bilateral treatment between the institutions involved.</strong><a href="#section-5.2.2.4-1.2" class="pilcrow">¶</a>
+</li>
+            </ul>
+
+<li id="section-5.2.2-3.20">shall refuse requests, for the Open Finance environment, that are outside the modes of operation to which the institution has certified its Authorization Server.<a href="#section-5.2.2-3.20" class="pilcrow">¶</a>
+</li>
+<li id="section-5.2.2-3.21">must refuse authentication requests that include an id_token_hint, as the id_token held by the requester may contain Personally Identifiable Information, which could be sent unencrypted by the public client.<a href="#section-5.2.2-3.21" class="pilcrow">¶</a>
+</li>
+<li id="section-5.2.2-3.22">the minimum expiration time of `request_uri` must be 60 seconds.<a href="#section-5.2.2-3.22" class="pilcrow">¶</a>
+</li>
+  
           </ol>
 <div id="id-token-as-detached-signature">
 <section id="section-5.2.2.1">


### PR DESCRIPTION
Adição das informações no item 5.2.2:

18. shall ensure that, in case of sharing the Authorization Server for other services, in addition to Open Finance, it does not disclose and/or allow the use of non-certified methods in the Open Finance environment;
19. shall ensure that the settings disclosed to other participants through `OpenID Discovery` (indicated by the `Well-Known` file registered in the Directory) are restricted to the operating modes to which the institution has certified;
    1. shall keep in your settings the methods for which there are still active clients;
    2. shall update the records that use non-certified methods, through bilateral treatment between the institutions involved.
20. shall refuse requests, for the Open Finance environment, that are outside the modes of operation to which the institution has certified its Authorization Server;
21. must refuse authentication requests that include an id_token_hint, as the id_token held by the requester may contain Personally Identifiable Information, which could be sent unencrypted by the public client.
22. the minimum expiration time of `request_uri` must be 60 seconds.

