### PR TITLE
Fix/dynamic client registration 1 id3

### DIFF
--- a/open-banking-brasil-dynamic-client-registration-1_ID3-ptbr.html
+++ b/open-banking-brasil-dynamic-client-registration-1_ID3-ptbr.html
@@ -1327,8 +1327,12 @@ li > p:last-of-type {
 </li>
                 </ul>
 </li>
-            </ul>
+            <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.2">
+                <p id="section-toc.1-1.9.2.2"><a href="#section-9.4" class="xref">9.4</a>.  <a href="#validacao-certificados" class="xref">Validação de certificados de assinatura</a></p>
 </li>
+            </ul>
+
+  </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
             <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-reconhecimento" class="xref">Reconhecimento</a></p>
 </li>
@@ -2377,6 +2381,36 @@ Para estender as <a href="https://tools.ietf.org/html/rfc7591">RFC7591</a> e <a 
 </section>
 </div>
 </section>
+</div>
+ <div id="validacao-certificados">
+<section id="section-9.4">
+          <h3 id="validacao-certificados">
+<a href="#section-9.4" class="section-number selfRef">9.4. </a><a href="#validacao-certificados" class="section-name selfRef">Validação de certificados de assinatura </a>
+          </h3>
+		  
+<ul>
+	<li> O diretório realiza a Valida&#231;&#227;o do certificado de assinatura através da função <b> cert rescan</b>, a cada hora. </li>
+	<li> As instituições devem assegurar que o processo de validação é realizado. </li>
+	<li> Cada instituição deve ter alternativa de contingência em caso de indisponibilidade do serviço de validação realizado pelo diretório. </li>
+	<li> Ao identificar que o certificado de assinatura <b> não é válido pois </b>, está com status <b> revogado </b> de acordo com o OCSP/CRL da CA emissora, ou está <b> inativo </b> no cadastro do diretório, o conjunto de chaves públicas é movido para o repositório de chaves inativas (Inactive Keystore). </li>
+	<li> É recomendado que o processo de validação inclua: </li>
+	<ul>
+		<li> Validação da assinatura da mensagem do Transmissor de Dados, a ser feita pelo Receptor de Dados </li>
+		<ul>
+			<li> Validar se a mensagem está assinada conforme o Message <i> Signature Guidelines </i>, incluindo se o <i> iss </i> é igual ao <i> organisation_id </i> do servidor que emitiu a mensagem.</li>
+		    <li> Buscar a declaração <i> iss </i> do JWT e gerar URI do JWKS publicado no diretório, para consulta. </li>
+			<li> Certificar se o <i> kid </i> do cabeçalho JWT da mensagem está presente no diretório JWKS. </li>
+			<li>  Validar se a chave privada para o <i>kid</i> correspondente é capaz de validar a assinatura da mensagem. </li>
+		</ul>
+		<li> Validação da assinatura da mensagem do Receptor de Dados, a ser feita pelo Transmissor de Dados </li>
+		<ul>
+			<li> Validar se a mensagem está assinada conforme o Message <i> Signature Guidelines </i>, incluindo se o <i> iss </i> é igual ao <i> organisation_id </i> do servidor que emitiu a mensagem.</li>
+		    <li> Obter o <i> org_jwks_uri</i> que foi apresentado no SSA pelo cliente no momento do DCR. </li>
+			<li> Certificar se o <i> kid </i> do cabeçalho JWT da mensagem está presente no diretório JWKS. </li>
+			<li>  Validar se a chave privada para o <i>kid</i> correspondente é capaz de validar a assinatura da mensagem. </li>
+		</ul>
+	</ul>
+</ul>
 </div>
 <div id="acknowledgements">
 <section id="section-10">

--- a/open-banking-brasil-dynamic-client-registration-1_ID3-ptbr.md
+++ b/open-banking-brasil-dynamic-client-registration-1_ID3-ptbr.md
@@ -586,6 +586,23 @@ Para estender as [RFC7591] e [RFC7592], que recomendam mecanismos mínimos para 
 
 *Observação:* A [RFC7592] prevê a possibilidade de rotação do `registration_access_token` emitido pelo Servidor de Autorização a cada uso, tornando-o um token de uso único. As instituições devem considerar esse aspecto no registro de suas aplicações cliente para receber e atualizar o `registration_access_token` pelo novo valor recebido nas chamadas de manutenção de cliente.
 
+##  Validação de certificados de assinatura
+* O diretório realiza a validação do certificado de assinatura através da função **cert rescan**, a cada hora.
+* As instituições devem assegurar que o processo de validação é realizado.
+*  Cada instituição deve ter alternativa de contingência em caso de indisponibilidade do serviço de validação realizado pelo diretório.
+* Ao identificar que o certificado de assinatura **não é válido** pois, está com status **revogado** de acordo com o OCSP/CRL da CA emissora, ou está **inativo** no cadastro do diretório, o conjunto de chaves públicas é movido para o repositório de chaves inativas (Inactive Keystore).
+* É recomendado que o processo de validação inclua:
+    * Validação da assinatura da mensagem do Transmissor de Dados, a ser feita pelo Receptor de Dados
+        * Validar se a mensagem está assinada conforme o *Message Signature Guidelines*, incluindo se o *iss* é igual ao organisation_id do servidor que emitiu a mensagem.
+        * Buscar a declaração iss do JWT e gerar URI do JWKS publicado no diretório, para consulta.
+        * Certificar se o *kid* do cabeçalho JWT da mensagem está presente no diretório JWKS.
+        * Validar se a chave privada para o *kid* correspondente é capaz de validar a assinatura da mensagem.
+    * Validação da assinatura da mensagem do Receptor de Dados, a ser feita pelo Transmissor de Dados
+        * Validar se a mensagem está assinada conforme o *Message Signature Guidelines*.
+        * Obter o org_jwks_uri que foi apresentado no SSA pelo cliente no momento do DCR.
+        *  Certificar se o *kid* do cabeçalho JWT da mensagem está presente no diretório JWKS.
+        *  Validar se a chave privada para o *kid* correspondente é capaz de validar a assinatura da mensagem.
+
 # Reconhecimento  {#acknowledgements}
 
 Agradecemos a todos que estabeleceram as bases para o compartilhamento seguro de dados por meio da formação do Grupo de Trabalho OpenID Foundation FAPI, o GT de Segurança do Open Finance Brasil e aos pioneiros que ficarão em seus ombros.

--- a/open-banking-brasil-dynamic-client-registration-1_ID3.html
+++ b/open-banking-brasil-dynamic-client-registration-1_ID3.html
@@ -1320,6 +1320,10 @@ These key words are not to be used as lexicon terms such that any occurrence of 
 </li>
                 </ul>
 </li>
+  </li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.2">
+                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.4" class="xref">9.4</a>.  <a href="#validation-certificate" class="xref"> Signature certificates validation </a></p>
+</li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
@@ -2371,6 +2375,36 @@ Content-Type: application/json
 </section>
 </div>
 </section>
+</div>
+<div id="certificates-validation">
+<section id="section-9.4">
+          <h3 id="validation-certificate">
+<a href="#section-9.4" class="section-number selfRef">9.4. </a><a href="#validation-certificate" class="section-name selfRef">Signature certificates validation </a>
+          </h3>
+		  
+<ul>
+	<li> The directory uses cert <b> cert rescan</b> function hourly to validation process. </li>
+	<li> The organization shall ensure that the validation process was completed. </li>
+	<li> Each organization must have a continuity plan in case of unavailability validation service. </li>
+	<li> If the signature certificate is not valid because it has a revoked status according to the CA’s OCSP/CRL issuer, or is inactive in the directory register, the set of public keys is moved to the inactive key storage. </li>
+	<li> The validation process should include </li>
+	<ul>
+		<li> Resource server (Data Transmitter) message signature validation, to be done by the Client (Data Receiver) </li>
+		<ul>
+			<li> Validate that the message was signed in line with what’s defined on the <i> Message Signature Guidelines </i> , including that the <i> iss </i>  is equal to the <i> organisation_id </i> of the server that issued the message. </li>
+		    <li> Fetch the “<i>iss</i>” claim from the JWT and build the directory application JWKS uri for that specific server. </li>
+			<li> Make sure that the <i> kid </i> present on the message JWT header is present on the directory JWKS. </li>
+			<li> Validate that the private key for the corresponding <i> kid </i> is able to validate the message signature. </li>
+		</ul>
+		<li> Validação da assinatura da mensagem do Receptor de Dados, a ser feita pelo Transmissor de Dados </li>
+		<ul>
+			<li> Validate how the message was signed in line with what’s defined on the Message Signature Guidelines. </li>
+		    <li> Obtain the org_jwks_uri which was presented on the SSA by the client on the moment of the registration (DCR) </li>
+			<li>  Make sure that the <i> kid </i> present on the message JWT header is present on the directory JWKS. </li>
+			<li> Validate that the private key for the corresponding <i> kid </i> is able to validate the message signature. </li>
+		</ul>
+	</ul>
+</ul>
 </div>
 <div id="acknowledgement">
 <section id="section-10">

--- a/open-banking-brasil-dynamic-client-registration-1_ID3.html
+++ b/open-banking-brasil-dynamic-client-registration-1_ID3.html
@@ -2395,7 +2395,7 @@ Content-Type: application/json
 			<li> Make sure that the <i> kid </i> present on the message JWT header is present on the directory JWKS. </li>
 			<li> Validate that the private key for the corresponding <i> kid </i> is able to validate the message signature. </li>
 		</ul>
-		<li> Validação da assinatura da mensagem do Receptor de Dados, a ser feita pelo Transmissor de Dados </li>
+		<li> Client (Data Receiver) message signature validation, to be done by the Resource Server </li>
 		<ul>
 			<li> Validate how the message was signed in line with what’s defined on the Message Signature Guidelines. </li>
 		    <li> Obtain the org_jwks_uri which was presented on the SSA by the client on the moment of the registration (DCR) </li>

--- a/open-banking-brasil-dynamic-client-registration-1_ID3.html
+++ b/open-banking-brasil-dynamic-client-registration-1_ID3.html
@@ -1320,7 +1320,6 @@ These key words are not to be used as lexicon terms such that any occurrence of 
 </li>
                 </ul>
 </li>
-  </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.2">
                 <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.4" class="xref">9.4</a>.  <a href="#validation-certificate" class="xref"> Signature certificates validation </a></p>
 </li>

--- a/open-banking-brasil-dynamic-client-registration-1_ID3.md
+++ b/open-banking-brasil-dynamic-client-registration-1_ID3.md
@@ -583,6 +583,23 @@ To extend [RFC7591] and [RFC7592], which recommend minimum mechanisms for authen
 
 Note: [RFC7592] provides the possibility of rotating the `registration_access_token` issued by the Authorization Server with each use, making it a single-use token. When registering their client applications, institutions should consider this aspect to receive and update the `registration_access_token` for the new value received in client maintenance (DCM) operations.
 
+## Signature certificates validation
+* The directory uses cert **rescan** function hourly to validation process.
+* The organization shall ensure that the validation process was completed.
+* Each organization must have a continuity plan in case of unavailability validation service.
+* If the signature certificate is not valid because it has a revoked status according to the CA’s OCSP/CRL issuer, or is inactive in the directory register, the set of public keys is moved to the inactive key storage.
+* The validation process should include:
+    * Resource server (Data Transmitter) message signature validation, to be done by the Client (Data Receiver)
+        * Validate that the message was signed in line with what’s defined on the Message Signature Guidelines, including that the iss is equal to the organisation_id of the server that issued the message.
+        * Fetch the “iss” claim from the JWT and build the directory application JWKS uri for that specific server.
+        * Make sure that the kid present on the message JWT header is present on the directory JWKS.
+        * Validate that the private key for the corresponding kid is able to validate the message signature.
+    * Client (Data Receiver) message signature validation, to be done by the Resource Server
+        * Validate how the message was signed in line with what’s defined on the Message Signature Guidelines.
+        * Obtain the org_jwks_uri which was presented on the SSA by the client on the moment of the registration (DCR).
+        * Make sure that the kid present on the message JWT header is present on the directory JWKS.
+        * Validate that the private key for the corresponding kid is able to validate the message signature.
+
 # Acknowledgement
 
 With thanks to all who have set the foundations for secure and safe data sharing through the formation of the OpenID Foundation FAPI Working Group, the Open Finance Brasil GT Security and to the pioneers who will stand on their shoulders.


### PR DESCRIPTION
Foi criado a seção 9.4 para os seguintes documentos:

open-banking-brasil-dynamic-client-registration-1_ID3-ptbr.html
open-banking-brasil-dynamic-client-registration-1_ID3-ptbr.md
open-banking-brasil-dynamic-client-registration-1_ID3.html
open-banking-brasil-dynamic-client-registration-1_ID3.md

A seção 9.4 adicionada é:

9.4. Validação de certificados de assinatura
•	O diretório realiza a validação do certificado de assinatura através da função cert rescan, a cada hora.
•	As instituições devem assegurar que o processo de validação é realizado.
•	Cada instituição deve ter alternativa de contingência em caso de indisponibilidade do serviço de validação realizado pelo diretório.
•	Ao identificar que o certificado de assinatura não é válido pois, está com status revogado de acordo com o OCSP/CRL da CA emissora, ou está inativo no cadastro do diretório, o conjunto de chaves públicas é movido para o repositório de chaves inativas (Inactive Keystore).
•	É recomendado que o processo de validação inclua:
o	Validação da assinatura da mensagem do Transmissor de Dados, a ser feita pelo Receptor de Dados
	Validar se a mensagem está assinada conforme o Message Signature Guidelines, incluindo se o iss é igual ao organisation_id do servidor que emitiu a mensagem.
	Buscar a declaração iss do JWT e gerar URI do JWKS publicado no diretório, para consulta.
	Certificar se o kid do cabeçalho JWT da mensagem está presente no diretório JWKS.
	Validar se a chave privada para o kid correspondente é capaz de validar a assinatura da mensagem.
o	Validação da assinatura da mensagem do Receptor de Dados, a ser feita pelo Transmissor de Dados
	Validar se a mensagem está assinada conforme o Message Signature Guidelines.
	Obter o org_jwks_uri que foi apresentado no SSA pelo cliente no momento do DCR.
	Certificar se o kid do cabeçalho JWT da mensagem está presente no diretório JWKS.
	Validar se a chave privada para o kid correspondente é capaz de validar a assinatura da mensagem.
 
9.4. Signature certificates validation
•	The directory uses cert rescan function hourly to validation process. 
•	The organization shall ensure that the validation process was completed.
•	Each organization must have a continuity plan in case of unavailability validation service.
•	If the signature certificate is not valid because it has a revoked status according to the CA’s OCSP/CRL issuer, or is inactive in the directory register, the set of public keys is moved to the inactive key storage.
•	The validation process should include:
o	Resource server (Data Transmitter) message signature validation, to be done by the Client (Data Receiver)
	Validate that the message was signed in line with what’s defined on the Message Signature Guidelines, including that the iss is equal to the organisation_id of the server that issued the message.
	Fetch the “iss” claim from the JWT and build the directory application JWKS uri for that specific server.
	Make sure that the kid present on the message JWT header is present on the directory JWKS.
	Validate that the private key for the corresponding kid is able to validate the message signature.
o	Client (Data Receiver) message signature validation, to be done by the Resource Server
	Validate how the message was signed in line with what’s defined on the Message Signature Guidelines.
	Obtain the org_jwks_uri which was presented on the SSA by the client on the moment of the registration (DCR)
	Make sure that the kid present on the message JWT header is present on the directory JWKS.
	Validate that the private key for the corresponding kid is able to validate the message signature.
