### PR TITLE
Fix/open banking brasil financial api 1 id3

### DIFF
--- a/open-banking-brasil-financial-api-1_ID3-ptbr.html
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.html
@@ -1941,10 +1941,14 @@ O valor para um dado usu&#225;rio nunca deve mudar dentro de uma institui&#231;&
 <p id="section-7.2.2-1">Al&#233;m dos requisitos descritos nas disposi&#231;&#245;es de seguran&#231;a do Open Finance Brasil, o Servidor de Autoriza&#231;&#227;o<a href="#section-7.2.2-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="compact type-1" id="section-7.2.2-2">
 <li id="section-7.2.2-2.1">deve apenas emitir _refresh<em>tokens</em> quando vinculados a um consentimento ativo e v&#225;lido;<a href="#section-7.2.2-2.1" class="pilcrow">¶</a>
-</li>
+  <ol type="i">
+    <li> Não deve emitir refresh_token quando o consentimento estiver no status “CONSUMED” (para fase 3); </li>
+    <li> Deve emitir um access_token por meio de um grant_type do tipo client credentials no status “CONSUMED” (para fase 3). </li>
+  </ol>
+  </li>
             <li id="section-7.2.2-2.2">
               <p id="section-7.2.2-2.2.1">s&#243; deve compartilhar o acesso aos recursos quando apresentado _access<em>token</em> vinculado a um consentimento ativo e com o status "AUTHORIZED";<a href="#section-7.2.2-2.2.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="compact type-1" id="section-7.2.2-2.2.2">
+<ol start="1" type="i" class="compact type-1" id="section-7.2.2-2.2.2">
 <li id="section-7.2.2-2.2.2.1">No cen&#225;rio de recebimento de token inv&#225;lido, deve ser retornado status code 401.<a href="#section-7.2.2-2.2.2.1" class="pilcrow">¶</a>
 </li>
               </ol>

--- a/open-banking-brasil-financial-api-1_ID3-ptbr.md
+++ b/open-banking-brasil-financial-api-1_ID3-ptbr.md
@@ -447,17 +447,19 @@ O recurso de consentimento tem um ciclo de vida gerenciado separada e distintame
 Além dos requisitos descritos nas disposições de segurança do Open Finance Brasil, o Servidor de Autorização
 
 1. deve apenas emitir _refresh_tokens_ quando vinculados a um consentimento ativo e válido;
-2. só deve compartilhar o acesso aos recursos quando apresentado _access_token_ vinculado a um consentimento ativo e com o status "AUTHORIZED";
+   1. Não deve emitir refresh_token quando o consentimento estiver no status “CONSUMED” (para fase 3);
+   2. Deve emitir um access_token por meio de um grant_type do tipo client credentials no status “CONSUMED” (para fase 3).
+3. só deve compartilhar o acesso aos recursos quando apresentado _access_token_ vinculado a um consentimento ativo e com o status "AUTHORIZED";
    1. No cenário de recebimento de token inválido, deve ser retornado status code 401.
-3. deve revogar os _refresh tokens_ e, quando aplicável, os _access tokens_ quando o Consentimento (Consent Resource) relacionado for apagado;
-4. deve garantir que os _access tokens_ são emitidos com os _scopes_ necessários para permitir acesso aos dados especificados em elemento _Permission_ do Consentimento (Consent Resource Object) relacionado;
-5. não deve rejeitar pedido de autorização com _scopes_ além do necessário para permitir acesso a dados definidos em elemento _Permission_ do Consentimento (Consent Resource Object) relacionado;
-6. pode reduzir o escopo solicitado para um nível que seja suficiente para permitir o acesso aos dados definidos em elemento _Permission_ do Consentimento (Consent Resource Object) relacionado;
-7. deve manter registros sobre o histórico dos consentimento para permitir a adequada formação de trilhas de auditoria em conformidade com a regulação em vigor;
-8. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o CPF do usuário autenticado não seja o mesmo indicado no elemento _loggedUser_ do Consentimento (Consent Resource Object);
-9. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o elemento _businessEntity_ não tenha sido preenchido no Consentimento (Consent Resource Object) relacionado e o usuário tenha selecionado ou se autenticado por meio de credencial relacionada à conta do tipo Pessoa Jurídica (PJ);
-10. deve condicionar a autenticação ou seleção de contas do tipo PJ à consistência entre o CNPJ relacionado à(s) conta(s) e o valor presente no elemento _businessEntity_ do Consentimento (Consent Resource Object). Em caso de divergência deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]);
-11. deve emitir _refresh_token_ com validade não inferior à validade do consentimento ao qual está relacionado, respeitado os demais critérios acima.
+4. deve revogar os _refresh tokens_ e, quando aplicável, os _access tokens_ quando o Consentimento (Consent Resource) relacionado for apagado;
+5. deve garantir que os _access tokens_ são emitidos com os _scopes_ necessários para permitir acesso aos dados especificados em elemento _Permission_ do Consentimento (Consent Resource Object) relacionado;
+6. não deve rejeitar pedido de autorização com _scopes_ além do necessário para permitir acesso a dados definidos em elemento _Permission_ do Consentimento (Consent Resource Object) relacionado;
+7. pode reduzir o escopo solicitado para um nível que seja suficiente para permitir o acesso aos dados definidos em elemento _Permission_ do Consentimento (Consent Resource Object) relacionado;
+8. deve manter registros sobre o histórico dos consentimento para permitir a adequada formação de trilhas de auditoria em conformidade com a regulação em vigor;
+9. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o CPF do usuário autenticado não seja o mesmo indicado no elemento _loggedUser_ do Consentimento (Consent Resource Object);
+10. deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]) caso o elemento _businessEntity_ não tenha sido preenchido no Consentimento (Consent Resource Object) relacionado e o usuário tenha selecionado ou se autenticado por meio de credencial relacionada à conta do tipo Pessoa Jurídica (PJ);
+11. deve condicionar a autenticação ou seleção de contas do tipo PJ à consistência entre o CNPJ relacionado à(s) conta(s) e o valor presente no elemento _businessEntity_ do Consentimento (Consent Resource Object). Em caso de divergência deve retornar falha na autenticação e o código de retorno _access_denied_ no parâmetro _erro_ (como especificado na seção 4.1.2.1 da [RFC6749]);
+12. deve emitir _refresh_token_ com validade não inferior à validade do consentimento ao qual está relacionado, respeitado os demais critérios acima.
 
 ### Cliente confidencial  {#clientconfidential}
 

--- a/open-banking-brasil-financial-api-1_ID3.html
+++ b/open-banking-brasil-financial-api-1_ID3.html
@@ -1919,9 +1919,15 @@ The value for a given user should never change within an institution, even acros
 <p id="section-7.2.2-1">In addition to the requirements outlined in Open Finance Brasil security provisions the Authorization Server<a href="#section-7.2.2-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="compact type-1" id="section-7.2.2-2">
 <li id="section-7.2.2-2.1">shall only issue _access<em>tokens</em> on presentation of a _refresh<em>token</em> when the consent resource the refresh token is bound to is active and with "AUTHORIZED" status;<a href="#section-7.2.2-2.1" class="pilcrow">¶</a>
-</li>
-            <li id="section-7.2.2-2.2">shall only share access to resources when presented with an _access<em>token</em> linked to an active and valid consent;
-2.1. In the Invalid Token Receive scenario, status code 401 should be returned.<a href="#section-7.2.2-2.2" class="pilcrow">¶</a>
+  <ol type="i">
+    <li> Must not issue refresh_token when consent status is "CONSUMED" (for phase 3) </li>
+    <li> Must issue an access_token through the grant_type client credentials when consent status is "CONSUMED"(for phase 3) </li>
+  </ol>
+ </li>
+            <li id="section-7.2.2-2.2">shall only share access to resources when presented with an _access<em>token</em> linked to an active and valid consent;>
+              <ol type = "i">
+                <li> In the Invalid Token Receive scenario, status code 401 should be returned.<a href="#section-7.2.2-2.2" class="pilcrow">¶</a> </li>
+              </ol>
 </li>
             <li id="section-7.2.2-2.3">shall revoke <em>refresh tokens</em> and, <em>access tokens</em> where aplicable, when the linked Consent Resource is deleted;<a href="#section-7.2.2-2.3" class="pilcrow">¶</a>
 </li>

--- a/open-banking-brasil-financial-api-1_ID3.md
+++ b/open-banking-brasil-financial-api-1_ID3.md
@@ -431,17 +431,19 @@ The Consent Resource has a life cycle that is managed seperately and distinctly 
 In addition to the requirements outlined in Open Finance Brasil security provisions the Authorization Server
 
 1. shall only issue _access_tokens_ on presentation of a _refresh_token_ when the consent resource the refresh token is bound to is active and with "AUTHORIZED" status;
-2. shall only share access to resources when presented with an _access_token_ linked to an active and valid consent;
-   2.1. In the Invalid Token Receive scenario, status code 401 should be returned.
-3. shall revoke _refresh tokens_ and, _access tokens_ where aplicable, when the linked Consent Resource is deleted;
-4. shall ensure _access tokens_ are issued with sufficient scope necessary for access to data specified in the _Permission_ element of a linked Consent Resource object;
-5. shall not reject an authorisation request requesting _scopes_ broader than those necessary to access data specified in the Permissions element of a linked Consent Resource object;
-6. may reduce requested scope to a level sufficient to enable access to data resources specified in the Permissions element of a linked Consent Resource object;
-7. shall retain a complete audit history of the consent resource in accordance with current Central Bank brazilian regulation;
-8. shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]) if the CPF of the authenticated user is not the same as indicated in the _loggedUser_ element of the Consent Resource Object;
-9. shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]) if the _businessEntity_ element has not been populated in the related Consent Resource Object and the user has selected or authenticated by using a credential related to a business account;
-10. an autenticated or selected business account´s CNPJ must match the value present in the _businessEntity_ element of the Consent Resource Object. In case of divergence authorization server shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]);
-11. shall ensure _refresh_tokens_ expiration time is at least equal to the linked consent resource expiration time.
+    1. Must not issue refresh_token when consent status is "CONSUMED" (for phase 3);
+    2. Must issue an access_token through the grant_type client credentials when consent status is "CONSUMED"(for phase 3).
+3. shall only share access to resources when presented with an _access_token_ linked to an active and valid consent;
+   1. In the Invalid Token Receive scenario, status code 401 should be returned.
+4. shall revoke _refresh tokens_ and, _access tokens_ where aplicable, when the linked Consent Resource is deleted;
+5. shall ensure _access tokens_ are issued with sufficient scope necessary for access to data specified in the _Permission_ element of a linked Consent Resource object;
+6. shall not reject an authorisation request requesting _scopes_ broader than those necessary to access data specified in the Permissions element of a linked Consent Resource object;
+7. may reduce requested scope to a level sufficient to enable access to data resources specified in the Permissions element of a linked Consent Resource object;
+8. shall retain a complete audit history of the consent resource in accordance with current Central Bank brazilian regulation;
+9. shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]) if the CPF of the authenticated user is not the same as indicated in the _loggedUser_ element of the Consent Resource Object;
+10. shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]) if the _businessEntity_ element has not been populated in the related Consent Resource Object and the user has selected or authenticated by using a credential related to a business account;
+11. an autenticated or selected business account´s CNPJ must match the value present in the _businessEntity_ element of the Consent Resource Object. In case of divergence authorization server shall return authentication failure and return code _access_denied_ in the _error_ parameter (as specified in section 4.1.2.1 of [RFC6749]);
+12. shall ensure _refresh_tokens_ expiration time is at least equal to the linked consent resource expiration time.
 
 ### Confidential Client
 


### PR DESCRIPTION
Foram alterados os seguintes arquivos:

open-banking-brasil-financial-api-1_ID3-ptbr.md
open-banking-brasil-financial-api-1_ID3-ptbr.html
open-banking-brasil-financial-api-1_ID3.md
open-banking-brasil-financial-api-1_ID3.html

Foram incluídos os seguintes textos:

(Versão Português):
i Não deve emitir refresh_token quando o consentimento estiver no status “CONSUMED” (para fase 3)
ii Deve emitir um access_token por meio de um grant_type do tipo client credentials no status “CONSUMED” (para fase 3)

(Versão inglês):
i. Must not issue refresh_token when consent status is "CONSUMED" (for phase 3)
ii. Must issue an access_token through the grant_type client credentials when consent status is "CONSUMED"(for phase 3)