### PR TITLE
Adição de parâmetros de webhook no DCR/DCM

### DIFF
--- a/dcr_review/dcr-dcm-swagger.yaml
+++ b/dcr_review/dcr-dcm-swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: Especificação dos serviços de registro dinâmico de cliente (DCR) e manutenção dinâmica de cliente (DCM), baseados nas especificações a seguir<br/> <ul><li>RFC 7591 - https://datatracker.ietf.org/doc/html/rfc7591</li><li>RFC 7592 - https://datatracker.ietf.org/doc/html/rfc7592<li>OpenID Connect Dynamic Client Registration -  https://openid.net/specs/openid-connect-registration-1_0.html</li></ul>
   contact:
     email: gt-seguranca@openfinancebrasil.org.br
-  version: 1.0.1
+  version: 1.1.0
 externalDocs:
   description: Documentação do processo de DCR / DCM no portal do desenvolvedor do Open Banking Brasil
   url: https://github.com/OpenBanking-Brasil/specs-seguranca/blob/main/open-banking-brasil-dynamic-client-registration-1_ID3.md
@@ -427,6 +427,7 @@ components:
             - invalid_client_metadata
             - invalid_software_statement
             - unapproved_software_statement
+            - invalid_webhook_uris
           description: códigos de erro de registro de cliente, usados como descrito na seção 3.2.2 da RFC 7591
         error_description:
           type: string
@@ -587,6 +588,13 @@ components:
             type: string
             maxLength: 255
             example: "https://mybank.com.br/apis/callback"
+        webhook_uris:
+          description: Array com as URLs a serem utilizadas como endereço base na composição utilizada para envio de webhooks de notificação.
+          type: array
+          items:
+            type: string
+            maxLength: 255
+            example: "https://www.myitp.com/mykong3"
   securitySchemes:
     OAuth2Security:
       type: oauth2


### PR DESCRIPTION
Adicionado o atributo webhook_uris no body da requisição do POST DCR e PUT DCM. Adicionado a opção invalid_webhook_uris no ENUM dos erros permitidos no POST DCR e PUT DCM