### PR TITLE
Adicionado validação de padrão via expressão regular para campo webhook_uris

### DIFF
--- a/dcr_review/dcr-dcm-swagger.yaml
+++ b/dcr_review/dcr-dcm-swagger.yaml
@@ -593,7 +593,8 @@ components:
           items:
             type: string
             maxLength: 255
-            example: "https://www.myitp.com/mykong3"
+            example: "https://www.myitp.com/mykong3/baseurl"
+            pattern: '^(https:\/\/[^\s\/?#]+(?:\/[^\s\/?#]+)*[^\/\s?#])$'
   securitySchemes:
     OAuth2Security:
       type: oauth2


### PR DESCRIPTION
Adicionada REGEXP para validar URLs. Foram usadas as seguintes para teste do pattern:
```regexp
^(https:\/\/[^\s\/?#]+(?:\/[^\s\/?#]+)*[^\/\s?#])$
```

URLs válidas:
https://www.myitp.com/mykong3
https://www.myitp.com/mykong3/qwe


URLs inválidas:
http://www.myitp.com/mykong3
https://www.myitp.com/mykong3/
https://www.myitp.com/mykong3/asd/
https://www.myitp.com/mykong3?hue=br
https://www.myitp.com/mykong3/asd/?hue=br&teste=123
https://www.myitp.com/mykong3?hue=br&teste=123&
https://www.myitp.com/mykong3?
